### PR TITLE
Feat/#3   onboarding views

### DIFF
--- a/Solidner.xcodeproj/project.pbxproj
+++ b/Solidner.xcodeproj/project.pbxproj
@@ -15,13 +15,17 @@
 		0E18AD742AFAA3430011ED4A /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 0E18AD732AFAA3430011ED4A /* FirebaseAnalytics */; };
 		0E18AD762AFAA3430011ED4A /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 0E18AD752AFAA3430011ED4A /* FirebaseAuth */; };
 		0E18AD782AFAA3430011ED4A /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 0E18AD772AFAA3430011ED4A /* FirebaseFirestore */; };
-		0E18AD7B2AFBDCE20011ED4A /* ComponentDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E18AD7A2AFBDCE20011ED4A /* ComponentDummy.swift */; };
 		0EA6C61E2AFBE087004FF2AA /* MonthlyPlanningDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA6C61D2AFBE087004FF2AA /* MonthlyPlanningDummy.swift */; };
+		B29CF7882AFCCA5B00B54A3E /* WeeklyPlanningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29CF7872AFCCA5B00B54A3E /* WeeklyPlanningView.swift */; };
+		B29CF78B2AFCCEA000B54A3E /* TextLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29CF78A2AFCCEA000B54A3E /* TextLiterals.swift */; };
 		C36942472AFCD687002465D4 /* ButtonComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36942462AFCD686002465D4 /* ButtonComponents.swift */; };
 		C36942492AFF755F002465D4 /* BackButtonHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36942482AFF755F002465D4 /* BackButtonHeader.swift */; };
 		C369424B2B00B350002465D4 /* TextFieldComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = C369424A2B00B350002465D4 /* TextFieldComponents.swift */; };
-		B29CF7882AFCCA5B00B54A3E /* WeeklyPlanningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29CF7872AFCCA5B00B54A3E /* WeeklyPlanningView.swift */; };
-		B29CF78B2AFCCEA000B54A3E /* TextLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29CF78A2AFCCEA000B54A3E /* TextLiterals.swift */; };
+		C369424D2B00C333002465D4 /* NickNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C369424C2B00C333002465D4 /* NickNameView.swift */; };
+		C369424F2B00C42C002465D4 /* OnboardingTitles.swift in Sources */ = {isa = PBXBuildFile; fileRef = C369424E2B00C42C002465D4 /* OnboardingTitles.swift */; };
+		C36942512B01185C002465D4 /* TextLimiterOB.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36942502B01185C002465D4 /* TextLimiterOB.swift */; };
+		C3AD1BC42B0126A2003BB3E0 /* KeyboardHeightHelperOB.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AD1BC32B0126A2003BB3E0 /* KeyboardHeightHelperOB.swift */; };
+		C3AD1BC62B012DA6003BB3E0 /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AD1BC52B012DA6003BB3E0 /* UIApplication+.swift */; };
 		C3C6375D2AF90C2B006D464D /* SolidnerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C6375C2AF90C2B006D464D /* SolidnerApp.swift */; };
 		C3C6375F2AF90C2B006D464D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C6375E2AF90C2B006D464D /* ContentView.swift */; };
 		C3C637612AF90C2C006D464D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C3C637602AF90C2C006D464D /* Assets.xcassets */; };
@@ -60,13 +64,17 @@
 		0E18AD6C2AFA8DC50011ED4A /* UserOB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserOB.swift; sourceTree = "<group>"; };
 		0E18AD6E2AFA8F140011ED4A /* AppleLoginOB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginOB.swift; sourceTree = "<group>"; };
 		0E18AD702AFA94E10011ED4A /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
-		0E18AD7A2AFBDCE20011ED4A /* ComponentDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentDummy.swift; sourceTree = "<group>"; };
 		0EA6C61D2AFBE087004FF2AA /* MonthlyPlanningDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyPlanningDummy.swift; sourceTree = "<group>"; };
+		B29CF7872AFCCA5B00B54A3E /* WeeklyPlanningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyPlanningView.swift; sourceTree = "<group>"; };
+		B29CF78A2AFCCEA000B54A3E /* TextLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextLiterals.swift; sourceTree = "<group>"; };
 		C36942462AFCD686002465D4 /* ButtonComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponents.swift; sourceTree = "<group>"; };
 		C36942482AFF755F002465D4 /* BackButtonHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButtonHeader.swift; sourceTree = "<group>"; };
 		C369424A2B00B350002465D4 /* TextFieldComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldComponents.swift; sourceTree = "<group>"; };
-		B29CF7872AFCCA5B00B54A3E /* WeeklyPlanningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyPlanningView.swift; sourceTree = "<group>"; };
-		B29CF78A2AFCCEA000B54A3E /* TextLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextLiterals.swift; sourceTree = "<group>"; };
+		C369424C2B00C333002465D4 /* NickNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NickNameView.swift; sourceTree = "<group>"; };
+		C369424E2B00C42C002465D4 /* OnboardingTitles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTitles.swift; sourceTree = "<group>"; };
+		C36942502B01185C002465D4 /* TextLimiterOB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextLimiterOB.swift; sourceTree = "<group>"; };
+		C3AD1BC32B0126A2003BB3E0 /* KeyboardHeightHelperOB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardHeightHelperOB.swift; sourceTree = "<group>"; };
+		C3AD1BC52B012DA6003BB3E0 /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
 		C3C637592AF90C2B006D464D /* Solidner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Solidner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C3C6375C2AF90C2B006D464D /* SolidnerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolidnerApp.swift; sourceTree = "<group>"; };
 		C3C6375E2AF90C2B006D464D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -116,6 +124,8 @@
 			isa = PBXGroup;
 			children = (
 				0E18AD6A2AFA7F670011ED4A /* SignInView.swift */,
+				C369424C2B00C333002465D4 /* NickNameView.swift */,
+				C369424E2B00C42C002465D4 /* OnboardingTitles.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -123,7 +133,6 @@
 		0E18AD792AFBDCD20011ED4A /* Components */ = {
 			isa = PBXGroup;
 			children = (
-				0E18AD7A2AFBDCE20011ED4A /* ComponentDummy.swift */,
 				C36942462AFCD686002465D4 /* ButtonComponents.swift */,
 				C36942482AFF755F002465D4 /* BackButtonHeader.swift */,
 				C369424A2B00B350002465D4 /* TextFieldComponents.swift */,
@@ -235,6 +244,8 @@
 			children = (
 				0E18AD6C2AFA8DC50011ED4A /* UserOB.swift */,
 				0E18AD6E2AFA8F140011ED4A /* AppleLoginOB.swift */,
+				C36942502B01185C002465D4 /* TextLimiterOB.swift */,
+				C3AD1BC32B0126A2003BB3E0 /* KeyboardHeightHelperOB.swift */,
 			);
 			path = ObservableObjects;
 			sourceTree = "<group>";
@@ -269,6 +280,7 @@
 			isa = PBXGroup;
 			children = (
 				C3C637912AF91E9D006D464D /* extension_dummy.swift */,
+				C3AD1BC52B012DA6003BB3E0 /* UIApplication+.swift */,
 			);
 			path = "Extension+";
 			sourceTree = "<group>";
@@ -434,19 +446,22 @@
 				C3C637902AF91E85006D464D /* fonts_dummy.swift in Sources */,
 				C3C6375F2AF90C2B006D464D /* ContentView.swift in Sources */,
 				0E18AD6B2AFA7F670011ED4A /* SignInView.swift in Sources */,
-				0EA6C61C2AFBE07A004FF2AA /* WeeklyPlanningDummy.swift in Sources */,
 				C36942492AFF755F002465D4 /* BackButtonHeader.swift in Sources */,
 				B29CF7882AFCCA5B00B54A3E /* WeeklyPlanningView.swift in Sources */,
 				0E18AD712AFA94E10011ED4A /* FirebaseManager.swift in Sources */,
+				C3AD1BC62B012DA6003BB3E0 /* UIApplication+.swift in Sources */,
+				C3AD1BC42B0126A2003BB3E0 /* KeyboardHeightHelperOB.swift in Sources */,
 				C3C637982AF91EE0006D464D /* models_dummy.swift in Sources */,
-				0E18AD7B2AFBDCE20011ED4A /* ComponentDummy.swift in Sources */,
 				0E18AD6F2AFA8F140011ED4A /* AppleLoginOB.swift in Sources */,
 				0EA6C61E2AFBE087004FF2AA /* MonthlyPlanningDummy.swift in Sources */,
 				C3C637942AF91EB0006D464D /* common_dummy.swift in Sources */,
+				C369424F2B00C42C002465D4 /* OnboardingTitles.swift in Sources */,
 				C3C6378E2AF91E73006D464D /* network_dummy.swift in Sources */,
 				C3C637922AF91E9D006D464D /* extension_dummy.swift in Sources */,
 				C3C6375D2AF90C2B006D464D /* SolidnerApp.swift in Sources */,
 				C369424B2B00B350002465D4 /* TextFieldComponents.swift in Sources */,
+				C369424D2B00C333002465D4 /* NickNameView.swift in Sources */,
+				C36942512B01185C002465D4 /* TextLimiterOB.swift in Sources */,
 				B29CF78B2AFCCEA000B54A3E /* TextLiterals.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Solidner.xcodeproj/project.pbxproj
+++ b/Solidner.xcodeproj/project.pbxproj
@@ -26,6 +26,10 @@
 		C36942512B01185C002465D4 /* TextLimiterOB.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36942502B01185C002465D4 /* TextLimiterOB.swift */; };
 		C3AD1BC42B0126A2003BB3E0 /* KeyboardHeightHelperOB.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AD1BC32B0126A2003BB3E0 /* KeyboardHeightHelperOB.swift */; };
 		C3AD1BC62B012DA6003BB3E0 /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AD1BC52B012DA6003BB3E0 /* UIApplication+.swift */; };
+		C3AD1BC82B021660003BB3E0 /* SoCuteNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AD1BC72B021660003BB3E0 /* SoCuteNameView.swift */; };
+		C3AD1BCA2B023FA1003BB3E0 /* BabyBirthDateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AD1BC92B023FA1003BB3E0 /* BabyBirthDateView.swift */; };
+		C3AD1BCC2B024FAC003BB3E0 /* FoodStartDateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AD1BCB2B024FAC003BB3E0 /* FoodStartDateView.swift */; };
+		C3AD1BD02B026CB5003BB3E0 /* OnboardingEndView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AD1BCF2B026CB5003BB3E0 /* OnboardingEndView.swift */; };
 		C3C6375D2AF90C2B006D464D /* SolidnerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C6375C2AF90C2B006D464D /* SolidnerApp.swift */; };
 		C3C6375F2AF90C2B006D464D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C6375E2AF90C2B006D464D /* ContentView.swift */; };
 		C3C637612AF90C2C006D464D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C3C637602AF90C2C006D464D /* Assets.xcassets */; };
@@ -75,6 +79,10 @@
 		C36942502B01185C002465D4 /* TextLimiterOB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextLimiterOB.swift; sourceTree = "<group>"; };
 		C3AD1BC32B0126A2003BB3E0 /* KeyboardHeightHelperOB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardHeightHelperOB.swift; sourceTree = "<group>"; };
 		C3AD1BC52B012DA6003BB3E0 /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
+		C3AD1BC72B021660003BB3E0 /* SoCuteNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoCuteNameView.swift; sourceTree = "<group>"; };
+		C3AD1BC92B023FA1003BB3E0 /* BabyBirthDateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BabyBirthDateView.swift; sourceTree = "<group>"; };
+		C3AD1BCB2B024FAC003BB3E0 /* FoodStartDateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoodStartDateView.swift; sourceTree = "<group>"; };
+		C3AD1BCF2B026CB5003BB3E0 /* OnboardingEndView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingEndView.swift; sourceTree = "<group>"; };
 		C3C637592AF90C2B006D464D /* Solidner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Solidner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C3C6375C2AF90C2B006D464D /* SolidnerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolidnerApp.swift; sourceTree = "<group>"; };
 		C3C6375E2AF90C2B006D464D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -126,6 +134,10 @@
 				0E18AD6A2AFA7F670011ED4A /* SignInView.swift */,
 				C369424C2B00C333002465D4 /* NickNameView.swift */,
 				C369424E2B00C42C002465D4 /* OnboardingTitles.swift */,
+				C3AD1BC72B021660003BB3E0 /* SoCuteNameView.swift */,
+				C3AD1BC92B023FA1003BB3E0 /* BabyBirthDateView.swift */,
+				C3AD1BCB2B024FAC003BB3E0 /* FoodStartDateView.swift */,
+				C3AD1BCF2B026CB5003BB3E0 /* OnboardingEndView.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -388,11 +400,12 @@
 			};
 			buildConfigurationList = C3C637542AF90C2B006D464D /* Build configuration list for PBXProject "Solidner" */;
 			compatibilityVersion = "Xcode 14.0";
-			developmentRegion = en;
+			developmentRegion = ko;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 				Base,
+				ko,
 			);
 			mainGroup = C3C637502AF90C2B006D464D;
 			packageReferences = (
@@ -453,14 +466,18 @@
 				C3AD1BC42B0126A2003BB3E0 /* KeyboardHeightHelperOB.swift in Sources */,
 				C3C637982AF91EE0006D464D /* models_dummy.swift in Sources */,
 				0E18AD6F2AFA8F140011ED4A /* AppleLoginOB.swift in Sources */,
+				C3AD1BCC2B024FAC003BB3E0 /* FoodStartDateView.swift in Sources */,
+				C3AD1BD02B026CB5003BB3E0 /* OnboardingEndView.swift in Sources */,
 				0EA6C61E2AFBE087004FF2AA /* MonthlyPlanningDummy.swift in Sources */,
 				C3C637942AF91EB0006D464D /* common_dummy.swift in Sources */,
 				C369424F2B00C42C002465D4 /* OnboardingTitles.swift in Sources */,
 				C3C6378E2AF91E73006D464D /* network_dummy.swift in Sources */,
 				C3C637922AF91E9D006D464D /* extension_dummy.swift in Sources */,
 				C3C6375D2AF90C2B006D464D /* SolidnerApp.swift in Sources */,
+				C3AD1BCA2B023FA1003BB3E0 /* BabyBirthDateView.swift in Sources */,
 				C369424B2B00B350002465D4 /* TextFieldComponents.swift in Sources */,
 				C369424D2B00C333002465D4 /* NickNameView.swift in Sources */,
+				C3AD1BC82B021660003BB3E0 /* SoCuteNameView.swift in Sources */,
 				C36942512B01185C002465D4 /* TextLimiterOB.swift in Sources */,
 				B29CF78B2AFCCEA000B54A3E /* TextLiterals.swift in Sources */,
 			);

--- a/Solidner.xcodeproj/project.pbxproj
+++ b/Solidner.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		0E18AD7B2AFBDCE20011ED4A /* ComponentDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E18AD7A2AFBDCE20011ED4A /* ComponentDummy.swift */; };
 		0EA6C61C2AFBE07A004FF2AA /* WeeklyPlanningDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA6C61B2AFBE07A004FF2AA /* WeeklyPlanningDummy.swift */; };
 		0EA6C61E2AFBE087004FF2AA /* MonthlyPlanningDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA6C61D2AFBE087004FF2AA /* MonthlyPlanningDummy.swift */; };
+		C36942472AFCD687002465D4 /* ButtonComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36942462AFCD686002465D4 /* ButtonComponents.swift */; };
+		C36942492AFF755F002465D4 /* BackButtonHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36942482AFF755F002465D4 /* BackButtonHeader.swift */; };
 		C3C6375D2AF90C2B006D464D /* SolidnerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C6375C2AF90C2B006D464D /* SolidnerApp.swift */; };
 		C3C6375F2AF90C2B006D464D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C6375E2AF90C2B006D464D /* ContentView.swift */; };
 		C3C637612AF90C2C006D464D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C3C637602AF90C2C006D464D /* Assets.xcassets */; };
@@ -59,6 +61,8 @@
 		0E18AD7A2AFBDCE20011ED4A /* ComponentDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentDummy.swift; sourceTree = "<group>"; };
 		0EA6C61B2AFBE07A004FF2AA /* WeeklyPlanningDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyPlanningDummy.swift; sourceTree = "<group>"; };
 		0EA6C61D2AFBE087004FF2AA /* MonthlyPlanningDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyPlanningDummy.swift; sourceTree = "<group>"; };
+		C36942462AFCD686002465D4 /* ButtonComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponents.swift; sourceTree = "<group>"; };
+		C36942482AFF755F002465D4 /* BackButtonHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButtonHeader.swift; sourceTree = "<group>"; };
 		C3C637592AF90C2B006D464D /* Solidner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Solidner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C3C6375C2AF90C2B006D464D /* SolidnerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolidnerApp.swift; sourceTree = "<group>"; };
 		C3C6375E2AF90C2B006D464D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -116,6 +120,8 @@
 			isa = PBXGroup;
 			children = (
 				0E18AD7A2AFBDCE20011ED4A /* ComponentDummy.swift */,
+				C36942462AFCD686002465D4 /* ButtonComponents.swift */,
+				C36942482AFF755F002465D4 /* BackButtonHeader.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -410,10 +416,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				0E18AD6D2AFA8DC50011ED4A /* UserOB.swift in Sources */,
+				C36942472AFCD687002465D4 /* ButtonComponents.swift in Sources */,
 				C3C637902AF91E85006D464D /* fonts_dummy.swift in Sources */,
 				C3C6375F2AF90C2B006D464D /* ContentView.swift in Sources */,
 				0E18AD6B2AFA7F670011ED4A /* SignInView.swift in Sources */,
 				0EA6C61C2AFBE07A004FF2AA /* WeeklyPlanningDummy.swift in Sources */,
+				C36942492AFF755F002465D4 /* BackButtonHeader.swift in Sources */,
 				0E18AD712AFA94E10011ED4A /* FirebaseManager.swift in Sources */,
 				C3C637982AF91EE0006D464D /* models_dummy.swift in Sources */,
 				0E18AD7B2AFBDCE20011ED4A /* ComponentDummy.swift in Sources */,

--- a/Solidner.xcodeproj/project.pbxproj
+++ b/Solidner.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		0EA6C61E2AFBE087004FF2AA /* MonthlyPlanningDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA6C61D2AFBE087004FF2AA /* MonthlyPlanningDummy.swift */; };
 		C36942472AFCD687002465D4 /* ButtonComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36942462AFCD686002465D4 /* ButtonComponents.swift */; };
 		C36942492AFF755F002465D4 /* BackButtonHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36942482AFF755F002465D4 /* BackButtonHeader.swift */; };
+		C369424B2B00B350002465D4 /* TextFieldComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = C369424A2B00B350002465D4 /* TextFieldComponents.swift */; };
 		C3C6375D2AF90C2B006D464D /* SolidnerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C6375C2AF90C2B006D464D /* SolidnerApp.swift */; };
 		C3C6375F2AF90C2B006D464D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C6375E2AF90C2B006D464D /* ContentView.swift */; };
 		C3C637612AF90C2C006D464D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C3C637602AF90C2C006D464D /* Assets.xcassets */; };
@@ -63,6 +64,7 @@
 		0EA6C61D2AFBE087004FF2AA /* MonthlyPlanningDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyPlanningDummy.swift; sourceTree = "<group>"; };
 		C36942462AFCD686002465D4 /* ButtonComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponents.swift; sourceTree = "<group>"; };
 		C36942482AFF755F002465D4 /* BackButtonHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButtonHeader.swift; sourceTree = "<group>"; };
+		C369424A2B00B350002465D4 /* TextFieldComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldComponents.swift; sourceTree = "<group>"; };
 		C3C637592AF90C2B006D464D /* Solidner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Solidner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C3C6375C2AF90C2B006D464D /* SolidnerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolidnerApp.swift; sourceTree = "<group>"; };
 		C3C6375E2AF90C2B006D464D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -122,6 +124,7 @@
 				0E18AD7A2AFBDCE20011ED4A /* ComponentDummy.swift */,
 				C36942462AFCD686002465D4 /* ButtonComponents.swift */,
 				C36942482AFF755F002465D4 /* BackButtonHeader.swift */,
+				C369424A2B00B350002465D4 /* TextFieldComponents.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -431,6 +434,7 @@
 				C3C6378E2AF91E73006D464D /* network_dummy.swift in Sources */,
 				C3C637922AF91E9D006D464D /* extension_dummy.swift in Sources */,
 				C3C6375D2AF90C2B006D464D /* SolidnerApp.swift in Sources */,
+				C369424B2B00B350002465D4 /* TextFieldComponents.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Solidner/Extension+/UIApplication+.swift
+++ b/Solidner/Extension+/UIApplication+.swift
@@ -1,0 +1,25 @@
+//
+//  UIApplication+.swift
+//  Solidner
+//
+//  Created by 황지우2 on 2023/11/13.
+//
+
+import Foundation
+import SwiftUI
+ 
+extension UIApplication {
+    func hideKeyboard() {
+        guard let window = windows.first else { return }
+        let tapRecognizer = UITapGestureRecognizer(target: window, action: #selector(UIView.endEditing))
+        tapRecognizer.cancelsTouchesInView = false
+        tapRecognizer.delegate = self
+        window.addGestureRecognizer(tapRecognizer)
+    }
+ }
+ 
+extension UIApplication: UIGestureRecognizerDelegate {
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return false
+    }
+}

--- a/Solidner/Literal/TextLiterals.swift
+++ b/Solidner/Literal/TextLiterals.swift
@@ -26,6 +26,10 @@ enum TextLiterals {
         static var deleteAllCalendarsText: String { "캘린더 삭제" }
         static var deleteAllCalendarsButtonText: String { "삭제하기" }
     }
+    
+    enum Onboarding {
+        
+    }
 }
 
 

--- a/Solidner/Literal/TextLiterals.swift
+++ b/Solidner/Literal/TextLiterals.swift
@@ -27,9 +27,33 @@ enum TextLiterals {
         static var deleteAllCalendarsButtonText: String { "삭제하기" }
     }
     
-    enum Onboarding {
-        
+    enum NickName {
+        static var warningMessage: String { "닉네임은 최대 10자까지 입력이 가능해요." }
+        static var placeHolder: String { "최대 10자내로 입력이 가능해요." }
+        static var bigTitle: String { "닉네임을\n입력해주세요" }
     }
+    
+    enum SoCuteName {
+        static var cuteNameMessage: String { "정말 귀여운 이름이네요!" }
+    }
+    
+    enum BabyBirthDate {
+        static var cakeLabelText: String { "🎂" }
+        static var bigTitle: String { "의 생일" }
+        static var smallTitle: String {"아기의 생년월일을 입력해주세요."}
+    }
+    
+    enum FoodStartDate {
+        static var bigTitle: String { "언제부터 이유식을\n계획할까요?" }
+        static var smallTitle: String {"이미 이유식을 진행 중이라면\n처음 시작하신 날짜를 알려주세요"}
+    }
+    
+    enum OnboardingEnd {
+        static var bigTitle: String { "가장 쉬운\n이유식의 첫 시작" }
+        static var smallTitle: String {"이유식 플래닝을 함께 고고씽\n어쩌구저쩌구"}
+        static var buttonTitle: String {"솔리너 시작하기"}
+    }
+    
 }
 
 

--- a/Solidner/ObservableObjects/KeyboardHeightHelperOB.swift
+++ b/Solidner/ObservableObjects/KeyboardHeightHelperOB.swift
@@ -1,0 +1,33 @@
+//
+//  KeyboardHeightHelperOB.swift
+//  Solidner
+//
+//  Created by 황지우2 on 2023/11/13.
+//
+
+import SwiftUI
+
+class KeyboardHeightHelperOB: ObservableObject{
+    @Published var keyboardHeight: CGFloat = 0
+    
+    init() {
+        self.listenForKeyboardNotifications()
+    }
+    
+    private func listenForKeyboardNotifications() {
+        NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidShowNotification,
+                                               object: nil,
+                                               queue: .main) { (notification) in
+            guard let userInfo = notification.userInfo,
+                  let keyboardRect = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
+            
+            self.keyboardHeight = keyboardRect.height
+        }
+        
+        NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidHideNotification,
+                                               object: nil,
+                                               queue: .main) { (notification) in
+            self.keyboardHeight = 0
+        }
+    }
+}

--- a/Solidner/ObservableObjects/KeyboardHeightHelperOB.swift
+++ b/Solidner/ObservableObjects/KeyboardHeightHelperOB.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-class KeyboardHeightHelperOB: ObservableObject{
+final class KeyboardHeightHelperOB: ObservableObject {
     @Published var keyboardHeight: CGFloat = 0
     
     init() {

--- a/Solidner/ObservableObjects/KeyboardHeightHelperOB.swift
+++ b/Solidner/ObservableObjects/KeyboardHeightHelperOB.swift
@@ -20,7 +20,6 @@ final class KeyboardHeightHelperOB: ObservableObject {
                                                queue: .main) { (notification) in
             guard let userInfo = notification.userInfo,
                   let keyboardRect = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
-            
             self.keyboardHeight = keyboardRect.height
         }
         

--- a/Solidner/ObservableObjects/TextLimiterOB.swift
+++ b/Solidner/ObservableObjects/TextLimiterOB.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-class TextLimiterOB: ObservableObject {
+final class TextLimiterOB: ObservableObject {
     private let limit = 10
     @Published var value = "" {
         didSet {

--- a/Solidner/ObservableObjects/TextLimiterOB.swift
+++ b/Solidner/ObservableObjects/TextLimiterOB.swift
@@ -1,0 +1,23 @@
+//
+//  TextLimiterOB.swift
+//  Solidner
+//
+//  Created by 황지우2 on 2023/11/12.
+//
+
+import SwiftUI
+
+class TextLimiterOB: ObservableObject {
+    private let limit = 10
+    @Published var value = "" {
+        didSet {
+            if value.count > self.limit {
+                value = String(value.prefix(self.limit))
+                self.hasReachedLimit = true
+            } else {
+                self.hasReachedLimit = false
+            }
+        }
+    }
+    @Published var hasReachedLimit = false
+}

--- a/Solidner/SolidnerApp.swift
+++ b/Solidner/SolidnerApp.swift
@@ -24,7 +24,8 @@ struct SolidnerApp: App {
     @StateObject private var userOB = UserOB()
     var body: some Scene {
         WindowGroup {
-            SignInView().environmentObject(userOB)
+            //SignInView().environmentObject(userOB)
+            NickNameView()
         }
     }
 }

--- a/Solidner/SolidnerApp.swift
+++ b/Solidner/SolidnerApp.swift
@@ -25,7 +25,7 @@ struct SolidnerApp: App {
     var body: some Scene {
         WindowGroup {
             //SignInView().environmentObject(userOB)
-            NickNameView()
+            BabyBirthDateView()
         }
     }
 }

--- a/Solidner/Views/Components/BackButtonHeader.swift
+++ b/Solidner/Views/Components/BackButtonHeader.swift
@@ -9,35 +9,31 @@ import SwiftUI
 
 struct BackButtonHeader: View {
     let backButtonColor = Color(#colorLiteral(red: 0.0834152922, green: 0.0834152922, blue: 0.0834152922, alpha: 1)).opacity(0.4)
-    let backButtonFrameSize: CGFloat = 25
+    let backButtonFrameSize: CGFloat = 34
     let backButtonSymbolWidth: CGFloat = 8.5
     let backButtonSymbolHeight: CGFloat = 17
     let backButtonHorizontalPadding: CGFloat = 16.64
     let backButtonTopPadding: CGFloat = 6.73
     let backButtonSystemName = "chevron.left"
+    @State var action: ()->Void = {}
     
     var body: some View {
-        headerButton {
-            print("headerButtonPressed")
-        }
+        headerButton(action: action)
     }
     
     func headerButton(action: @escaping ()-> Void) -> some View {
-        return VStack {
-            HStack {
-                Button(action: action, label: {
-                        Rectangle()
-                        .fill(Color.clear)
-                        .frame(width: backButtonFrameSize, height: backButtonFrameSize)
-                        .overlay {
-                            Image(systemName: backButtonSystemName)
-                                .resizable()
-                                .frame(width: backButtonSymbolWidth, height: backButtonSymbolHeight)
-                                .foregroundColor(backButtonColor)
-                        }
-                })
-                Spacer()
-            }
+        return HStack {
+            Button(action: action, label: {
+                Rectangle()
+                    .fill(Color.clear)
+                    .frame(width: backButtonFrameSize, height: backButtonFrameSize)
+                    .overlay {
+                        Image(systemName: backButtonSystemName)
+                            .resizable()
+                            .frame(width: backButtonSymbolWidth, height: backButtonSymbolHeight)
+                            .foregroundColor(backButtonColor)
+                    }
+            })
             Spacer()
         }
         .padding(.horizontal, backButtonHorizontalPadding)

--- a/Solidner/Views/Components/BackButtonHeader.swift
+++ b/Solidner/Views/Components/BackButtonHeader.swift
@@ -1,0 +1,52 @@
+//
+//  BackButtonHeaderView.swift
+//  Solidner
+//
+//  Created by 황지우2 on 2023/11/11.
+//
+
+import SwiftUI
+
+struct BackButtonHeader: View {
+    let backButtonColor = Color(#colorLiteral(red: 0.0834152922, green: 0.0834152922, blue: 0.0834152922, alpha: 1)).opacity(0.4)
+    let backButtonFrameSize: CGFloat = 25
+    let backButtonSymbolWidth: CGFloat = 8.5
+    let backButtonSymbolHeight: CGFloat = 17
+    let backButtonHorizontalPadding: CGFloat = 16.64
+    let backButtonTopPadding: CGFloat = 6.73
+    let backButtonSystemName = "chevron.left"
+    
+    var body: some View {
+        headerButton {
+            print("headerButtonPressed")
+        }
+    }
+    
+    func headerButton(action: @escaping ()-> Void) -> some View {
+        return VStack {
+            HStack {
+                Button(action: action, label: {
+                        Rectangle()
+                        .fill(Color.clear)
+                        .frame(width: backButtonFrameSize, height: backButtonFrameSize)
+                        .overlay {
+                            Image(systemName: backButtonSystemName)
+                                .resizable()
+                                .frame(width: backButtonSymbolWidth, height: backButtonSymbolHeight)
+                                .foregroundColor(backButtonColor)
+                        }
+                })
+                Spacer()
+            }
+            Spacer()
+        }
+        .padding(.horizontal, backButtonHorizontalPadding)
+        .padding(.top, backButtonTopPadding)
+    }
+}
+
+struct BackButtonHeader_Previews: PreviewProvider {
+    static var previews: some View {
+        BackButtonHeader()
+    }
+}

--- a/Solidner/Views/Components/ButtonComponents.swift
+++ b/Solidner/Views/Components/ButtonComponents.swift
@@ -17,23 +17,23 @@ struct ButtonComponents: View {
     let buttonDisabledTextColor = Color(#colorLiteral(red: 0.2901960784, green: 0.2901960784, blue: 0.2901960784, alpha: 1))
     
     var body: some View {
-        tinyButton(title: "몰루",disabledCondition: false, action: {})
+        smallButton(disabledCondition: false, action: {})
     }
     
-    func bigButton(title: String, disabledCondition: Bool, action: @escaping ()->Void ) -> some View {
+    func bigButton(title: String = "다음" , disabledCondition: Bool, action: @escaping ()->Void, buttonColor: Color = Color.blue, titleColor: Color = Color.white) -> some View {
         return Button(action: action){
             RoundedRectangle(cornerRadius: buttonCornerRadius)
-                .fill(disabledCondition ? buttonDisabledColor : .blue)
+                .fill(disabledCondition ? buttonDisabledColor : buttonColor)
                 .frame(height: buttonHeight)
                 .overlay {
                     Text(title)
-                        .foregroundColor(disabledCondition ? buttonDisabledTextColor : .white)
+                        .foregroundColor(disabledCondition ? buttonDisabledTextColor : titleColor)
                 }
         }
         .disabled(disabledCondition)
     }
     
-    func smallButton(title: String, disabledCondition: Bool, action: @escaping () -> Void ) -> some View {
+    func smallButton(title: String = "다음", disabledCondition: Bool, action: @escaping () -> Void ) -> some View {
         return Button(action: action) {
             RoundedRectangle(cornerRadius: buttonCornerRadius)
                 .fill(disabledCondition ? buttonDisabledColor : .blue)

--- a/Solidner/Views/Components/ButtonComponents.swift
+++ b/Solidner/Views/Components/ButtonComponents.swift
@@ -1,0 +1,63 @@
+//
+//  ButtonComponents.swift
+//  Solidner
+//
+//  Created by 황지우2 on 2023/11/09.
+//
+
+import SwiftUI
+
+struct ButtonComponents: View {
+    let buttonHeight: CGFloat = 56
+    let smallButtonWidth: CGFloat = 138
+    let buttonCornerRadius: CGFloat = 12
+    let tinyButtonHeight: CGFloat = 48
+    let tinyButtonWidth: CGFloat = 96
+    
+    var body: some View {
+        tinyButton(title: "몰루",disabledCondition: false, action: {})
+    }
+    
+    func bigButton(title: String, disabledCondition: Bool, action: @escaping ()->Void ) -> some View {
+        return Button(action: action){
+            RoundedRectangle(cornerRadius: buttonCornerRadius)
+                .fill(.blue)
+                .frame(height: buttonHeight)
+                .overlay {
+                    Text(title)
+                        .foregroundColor(.white)
+                }
+        }
+    }
+    
+    func smallButton(title: String, disabledCondition: Bool, action: @escaping () -> Void ) -> some View {
+        return Button(action: action) {
+            RoundedRectangle(cornerRadius: buttonCornerRadius)
+                .fill(.blue)
+                .frame(width: smallButtonWidth, height: buttonHeight)
+                .overlay {
+                    Text(title)
+                        .foregroundColor(.white)
+                }
+        }
+    }
+    
+    func tinyButton(title: String, disabledCondition: Bool, action: @escaping () -> Void ) -> some View {
+        return Button(action: action) {
+            RoundedRectangle(cornerRadius: buttonCornerRadius)
+                .fill(.blue)
+                .frame(width: tinyButtonWidth, height: tinyButtonHeight)
+                .overlay {
+                    Text(title)
+                        .foregroundColor(.white)
+                }
+        }
+    }
+    
+}
+
+struct ButtonComponents_Previews: PreviewProvider {
+    static var previews: some View {
+        ButtonComponents()
+    }
+}

--- a/Solidner/Views/Components/ButtonComponents.swift
+++ b/Solidner/Views/Components/ButtonComponents.swift
@@ -13,6 +13,8 @@ struct ButtonComponents: View {
     let buttonCornerRadius: CGFloat = 12
     let tinyButtonHeight: CGFloat = 48
     let tinyButtonWidth: CGFloat = 96
+    let buttonDisabledColor = Color(#colorLiteral(red: 0.8705882353, green: 0.8705882353, blue: 0.8705882353, alpha: 1))
+    let buttonDisabledTextColor = Color(#colorLiteral(red: 0.2901960784, green: 0.2901960784, blue: 0.2901960784, alpha: 1))
     
     var body: some View {
         tinyButton(title: "몰루",disabledCondition: false, action: {})
@@ -21,37 +23,40 @@ struct ButtonComponents: View {
     func bigButton(title: String, disabledCondition: Bool, action: @escaping ()->Void ) -> some View {
         return Button(action: action){
             RoundedRectangle(cornerRadius: buttonCornerRadius)
-                .fill(.blue)
+                .fill(disabledCondition ? buttonDisabledColor : .blue)
                 .frame(height: buttonHeight)
                 .overlay {
                     Text(title)
-                        .foregroundColor(.white)
+                        .foregroundColor(disabledCondition ? buttonDisabledTextColor : .white)
                 }
         }
+        .disabled(disabledCondition)
     }
     
     func smallButton(title: String, disabledCondition: Bool, action: @escaping () -> Void ) -> some View {
         return Button(action: action) {
             RoundedRectangle(cornerRadius: buttonCornerRadius)
-                .fill(.blue)
+                .fill(disabledCondition ? buttonDisabledColor : .blue)
                 .frame(width: smallButtonWidth, height: buttonHeight)
                 .overlay {
                     Text(title)
-                        .foregroundColor(.white)
+                        .foregroundColor(disabledCondition ? buttonDisabledTextColor : .white)
                 }
         }
+        .disabled(disabledCondition)
     }
     
     func tinyButton(title: String, disabledCondition: Bool, action: @escaping () -> Void ) -> some View {
         return Button(action: action) {
             RoundedRectangle(cornerRadius: buttonCornerRadius)
-                .fill(.blue)
+                .fill(disabledCondition ? buttonDisabledColor : .blue)
                 .frame(width: tinyButtonWidth, height: tinyButtonHeight)
                 .overlay {
                     Text(title)
-                        .foregroundColor(.white)
+                        .foregroundColor(disabledCondition ? buttonDisabledTextColor : .white)
                 }
         }
+        .disabled(disabledCondition)
     }
     
 }

--- a/Solidner/Views/Components/TextFieldComponents.swift
+++ b/Solidner/Views/Components/TextFieldComponents.swift
@@ -1,0 +1,36 @@
+//
+//  TextFieldComponents.swift
+//  Solidner
+//
+//  Created by 황지우2 on 2023/11/12.
+//
+
+import SwiftUI
+
+struct TextFieldComponents: View {
+    let placeHolder = "최대 10자내로  입력이 가능해요."
+    let textFieldColor = Color(#colorLiteral(red: 0.9277959466, green: 0.9277958274, blue: 0.9277958274, alpha: 1))
+    let placeHolderColor = Color(#colorLiteral(red: 0.6429678202, green: 0.6429678202, blue: 0.6429678202, alpha: 1))
+    let textFieldCornerRadius: CGFloat = 12
+    let textFieldPadding: CGFloat = 16
+    @State var value = ""
+    @FocusState var isFocused: Bool
+    
+    var body: some View {
+        shortTextfield(placeHolder: placeHolder, value: $value, isFocused: $isFocused)
+    }
+    
+    func shortTextfield(placeHolder: String, value: Binding<String>, isFocused: FocusState<Bool>.Binding) -> some View {
+        TextField("", text: value, prompt: Text(placeHolder).foregroundColor(placeHolderColor))
+            .focused(isFocused)
+            .padding(textFieldPadding)
+            .background(textFieldColor)
+            .cornerRadius(textFieldCornerRadius)
+    }
+}
+
+struct TextFieldComponents_Previews: PreviewProvider {
+    static var previews: some View {
+        TextFieldComponents()
+    }
+}

--- a/Solidner/Views/Components/TextFieldComponents.swift
+++ b/Solidner/Views/Components/TextFieldComponents.swift
@@ -13,7 +13,7 @@ struct TextFieldComponents: View {
     let placeHolderColor = Color(#colorLiteral(red: 0.6429678202, green: 0.6429678202, blue: 0.6429678202, alpha: 1))
     let textFieldCornerRadius: CGFloat = 12
     let textFieldPadding: CGFloat = 16
-    @State var value = ""
+    @State private var value = ""
     @FocusState var isFocused: Bool
     
     var body: some View {

--- a/Solidner/Views/Onboarding/BabyBirthDateView.swift
+++ b/Solidner/Views/Onboarding/BabyBirthDateView.swift
@@ -1,0 +1,44 @@
+//
+//  BabyBirthDateView.swift
+//  Solidner
+//
+//  Created by 황지우2 on 2023/11/13.
+//
+
+import SwiftUI
+
+struct BabyBirthDateView: View {
+    let bigTitleColor = Color(#colorLiteral(red: 0.0834152922, green: 0.0834152922, blue: 0.0834152922, alpha: 1))
+    let smallTitleColor = Color(#colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)).opacity(0.6)
+    let cakeLabelFontSize = 32.0
+    let onboardingTitlesTopPadding = 10.0
+    let datePickerTopPadding = 70.0
+    @State var babyName = "찍무"
+    @State var babyBirthDate = Date()
+    var body: some View {
+        VStack(spacing: 0) {
+           BackButtonHeader()
+            viewBody()
+        }
+    }
+    func viewBody() -> some View {
+        VStack(spacing: 0) {
+            Text(TextLiterals.BabyBirthDate.cakeLabelText)
+                .font(.system(size: cakeLabelFontSize, weight: .bold))
+            OnboardingTitles(alignmentCase: .center, bigTitle: babyName+TextLiterals.BabyBirthDate.bigTitle , smallTitle: TextLiterals.BabyBirthDate.smallTitle)
+                .padding(.top, onboardingTitlesTopPadding)
+            DatePicker(selection: $babyBirthDate, in: ...Date(), displayedComponents: .date){}
+                .labelsHidden()
+                .datePickerStyle(WheelDatePickerStyle())
+                .padding(.top, datePickerTopPadding)
+            Spacer()
+            ButtonComponents().bigButton(disabledCondition: false, action: {})
+        }
+    }
+}
+
+struct BabyBirthDateView_Previews: PreviewProvider {
+    static var previews: some View {
+        BabyBirthDateView()
+    }
+}

--- a/Solidner/Views/Onboarding/BabyBirthDateView.swift
+++ b/Solidner/Views/Onboarding/BabyBirthDateView.swift
@@ -13,8 +13,8 @@ struct BabyBirthDateView: View {
     let cakeLabelFontSize = 32.0
     let onboardingTitlesTopPadding = 10.0
     let datePickerTopPadding = 70.0
-    @State var babyName = "찍무"
-    @State var babyBirthDate = Date()
+    @State private var babyName = "찍무"
+    @State private var babyBirthDate = Date()
     var body: some View {
         VStack(spacing: 0) {
            BackButtonHeader()

--- a/Solidner/Views/Onboarding/BabyBirthDateView.swift
+++ b/Solidner/Views/Onboarding/BabyBirthDateView.swift
@@ -21,7 +21,7 @@ struct BabyBirthDateView: View {
             viewBody()
         }
     }
-    func viewBody() -> some View {
+    private func viewBody() -> some View {
         VStack(spacing: 0) {
             Text(TextLiterals.BabyBirthDate.cakeLabelText)
                 .font(.system(size: cakeLabelFontSize, weight: .bold))

--- a/Solidner/Views/Onboarding/FoodStageSelectView.swift
+++ b/Solidner/Views/Onboarding/FoodStageSelectView.swift
@@ -1,0 +1,76 @@
+//
+//  FoodStageSelectView.swift
+//  Solidner
+//
+//  Created by 황지우2 on 2023/11/13.
+//
+
+import SwiftUI
+
+struct FoodStageSelectView: View {
+    let guidingBubbleColor = Color(#colorLiteral(red: 0.7149112821, green: 0.7669619918, blue: 0.6710264087, alpha: 1))
+    let dividerBubbleColor = Color(#colorLiteral(red: 0.8509803922, green: 0.8509803922, blue: 0.8509803922, alpha: 1)).opacity(0.2)
+    let downChevronColor = Color(#colorLiteral(red: 0.7176470588, green: 0.7176470588, blue: 0.7176470588, alpha: 1))
+    let foodStagePickerColor = Color(#colorLiteral(red: 0.5019607843, green: 0.5568627451, blue: 0.6745098039, alpha: 1)).opacity(0.1)
+    @State var dayNumber = 0.0
+    var body: some View {
+        VStack(spacing: 0) {
+            BackButtonHeader()
+            OnboardingTitles(bigTitle: "아이의 이유식 단계를\n확인해주세요!", smallTitle: "아이의 월령에 따라\n자동으로 단계를 입력했어요.")
+            HStack(alignment: .bottom, spacing: 0) {
+                Spacer()
+                VStack(spacing: 0) {
+                    Text("초기 전반 과정중 10일차에요")
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 18)
+                        .padding(.vertical, 12)
+                        .background(guidingBubbleColor)
+                    .cornerRadius(12)
+                    .padding(.bottom, 5)
+                }
+                Circle()
+                    .fill(guidingBubbleColor)
+                    .frame(width: 10, height: 10)
+                    .padding(.leading, 8)
+            }
+            .padding(.top, 50)
+            Rectangle()
+                .fill(dividerBubbleColor)
+                .frame(maxWidth: .infinity)
+                .frame(height: 10)
+                .padding(.top, 20)
+            VStack(spacing: 0) {
+                HStack {
+                    Text("이유식 단계")
+                        .font(.system(size: 19, weight: .semibold))
+                    Spacer()
+                }
+                HStack {
+                    Text("초기 전반 (6개월 전반)")
+                        .font(.system(size: 15, weight: .medium))
+                    Spacer()
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 18, weight: .bold))
+                        .foregroundColor(downChevronColor)
+                }
+                .padding(18)
+                .background(foodStagePickerColor)
+                .cornerRadius(12)
+                .padding(.top, 16)
+                HStack {
+                    Text("일차 수")
+                        .font(.system(size: 19, weight: .semibold))
+                    Spacer()
+                }
+            }
+            
+        }
+    }
+}
+
+struct FoodStageSelectView_Previews: PreviewProvider {
+    static var previews: some View {
+        FoodStageSelectView()
+    }
+}

--- a/Solidner/Views/Onboarding/FoodStartDateView.swift
+++ b/Solidner/Views/Onboarding/FoodStartDateView.swift
@@ -1,0 +1,36 @@
+//
+//  FoodStartDateView.swift
+//  Solidner
+//
+//  Created by 황지우2 on 2023/11/13.
+//
+
+import SwiftUI
+
+struct FoodStartDateView: View {
+    let datePickerTopPadding = 51.0
+    @State var solidStartDate = Date()
+    var body: some View {
+        VStack(spacing: 0) {
+            BackButtonHeader()
+            viewBody()
+        }
+    }
+    func viewBody() -> some View {
+        return VStack {
+            OnboardingTitles(bigTitle: TextLiterals.FoodStartDate.bigTitle, smallTitle: TextLiterals.FoodStartDate.smallTitle)
+            DatePicker(selection: $solidStartDate, displayedComponents: .date){}
+                .labelsHidden()
+                .datePickerStyle(WheelDatePickerStyle())
+                .padding(.top, datePickerTopPadding)
+            Spacer()
+            ButtonComponents().bigButton(disabledCondition: false, action: {})
+        }
+    }
+}
+
+struct FoodStartDateView_Previews: PreviewProvider {
+    static var previews: some View {
+        FoodStartDateView()
+    }
+}

--- a/Solidner/Views/Onboarding/FoodStartDateView.swift
+++ b/Solidner/Views/Onboarding/FoodStartDateView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct FoodStartDateView: View {
     let datePickerTopPadding = 51.0
-    @State var solidStartDate = Date()
+    @State private var solidStartDate = Date()
     var body: some View {
         VStack(spacing: 0) {
             BackButtonHeader()

--- a/Solidner/Views/Onboarding/FoodStartDateView.swift
+++ b/Solidner/Views/Onboarding/FoodStartDateView.swift
@@ -16,7 +16,7 @@ struct FoodStartDateView: View {
             viewBody()
         }
     }
-    func viewBody() -> some View {
+    private func viewBody() -> some View {
         return VStack {
             OnboardingTitles(bigTitle: TextLiterals.FoodStartDate.bigTitle, smallTitle: TextLiterals.FoodStartDate.smallTitle)
             DatePicker(selection: $solidStartDate, displayedComponents: .date){}

--- a/Solidner/Views/Onboarding/NickNameView.swift
+++ b/Solidner/Views/Onboarding/NickNameView.swift
@@ -13,8 +13,8 @@ struct NickNameView: View {
     private let warningMessageLeadingPadding = CGFloat(4)
     private let warningMessageColor = Color(#colorLiteral(red: 0.916901052, green: 0.4367357492, blue: 0.4184575677, alpha: 1))
     private let warningMessageFontSize = 11.5
-    @ObservedObject var textLimiter = TextLimiterOB()
-    @ObservedObject var keyboardHeightHelper = KeyboardHeightHelperOB()
+    @StateObject private var textLimiter = TextLimiterOB()
+    @StateObject private var keyboardHeightHelper = KeyboardHeightHelperOB()
     @FocusState private var isFocused: Bool
     var body: some View {
         GeometryReader { _ in

--- a/Solidner/Views/Onboarding/NickNameView.swift
+++ b/Solidner/Views/Onboarding/NickNameView.swift
@@ -1,0 +1,68 @@
+//
+//  NickNameView.swift
+//  Solidner
+//
+//  Created by 황지우2 on 2023/11/12.
+//
+
+import SwiftUI
+
+struct NickNameView: View {
+    private let textFieldTopPadding = CGFloat(16)
+    private let warningMessageTopPadding = CGFloat(12)
+    private let warningMessageLeadingPadding = CGFloat(4)
+    private let buttonTitle = "다음"
+    private let warningMessage = "닉네임은 최대 10자까지 입력이 가능해요."
+    private let placeHolder = "최대 10자내로 입력이 가능해요."
+    private let warningMessageColor = Color(#colorLiteral(red: 0.916901052, green: 0.4367357492, blue: 0.4184575677, alpha: 1))
+    private let warningMessageFontSize = 11.5
+    @State var bigTitle = "닉네임을\n입력해주세요"
+    @ObservedObject var textLimiter = TextLimiterOB()
+    @ObservedObject var keyboardHeightHelper = KeyboardHeightHelperOB()
+    @FocusState private var isFocused: Bool
+    var body: some View {
+        GeometryReader { _ in
+            VStack(spacing: 0) {
+                BackButtonHeader {
+                    print("~~")
+                }
+                viewBody()
+            }
+            .onAppear (perform : UIApplication.shared.hideKeyboard)
+        }
+        .ignoresSafeArea(.keyboard, edges: .bottom)
+    }
+    
+    private func viewBody() -> some View {
+        return VStack {
+            OnboardingTitles(bigTitle: bigTitle, isSmallTitleExist: false)
+            TextFieldComponents().shortTextfield(placeHolder: placeHolder, value: $textLimiter.value, isFocused: $isFocused)
+                .padding(.top, textFieldTopPadding)
+            if textLimiter.hasReachedLimit {
+                withAnimation {
+                    HStack {
+                        Text(warningMessage)
+                            .foregroundColor(warningMessageColor)
+                            .font(.system(size: warningMessageFontSize, weight: .semibold))
+                        .padding(.top, warningMessageTopPadding)
+                        .padding(.leading, warningMessageLeadingPadding)
+                        Spacer()
+                    }
+                }
+            }
+            Spacer()
+            HStack {
+                Spacer()
+                ButtonComponents().smallButton(title: buttonTitle, disabledCondition: textLimiter.value.isEmpty, action: {})
+                    .offset(y: isFocused ? -self.keyboardHeightHelper.keyboardHeight : 0)
+                    .animation(.easeIn(duration: 0.1), value: keyboardHeightHelper.keyboardHeight)
+            }
+        }
+    }
+}
+
+struct NickNameView_Previews: PreviewProvider {
+    static var previews: some View {
+        NickNameView()
+    }
+}

--- a/Solidner/Views/Onboarding/NickNameView.swift
+++ b/Solidner/Views/Onboarding/NickNameView.swift
@@ -11,12 +11,8 @@ struct NickNameView: View {
     private let textFieldTopPadding = CGFloat(16)
     private let warningMessageTopPadding = CGFloat(12)
     private let warningMessageLeadingPadding = CGFloat(4)
-    private let buttonTitle = "다음"
-    private let warningMessage = "닉네임은 최대 10자까지 입력이 가능해요."
-    private let placeHolder = "최대 10자내로 입력이 가능해요."
     private let warningMessageColor = Color(#colorLiteral(red: 0.916901052, green: 0.4367357492, blue: 0.4184575677, alpha: 1))
     private let warningMessageFontSize = 11.5
-    @State var bigTitle = "닉네임을\n입력해주세요"
     @ObservedObject var textLimiter = TextLimiterOB()
     @ObservedObject var keyboardHeightHelper = KeyboardHeightHelperOB()
     @FocusState private var isFocused: Bool
@@ -35,13 +31,13 @@ struct NickNameView: View {
     
     private func viewBody() -> some View {
         return VStack {
-            OnboardingTitles(bigTitle: bigTitle, isSmallTitleExist: false)
-            TextFieldComponents().shortTextfield(placeHolder: placeHolder, value: $textLimiter.value, isFocused: $isFocused)
+            OnboardingTitles(bigTitle: TextLiterals.NickName.bigTitle, isSmallTitleExist: false)
+            TextFieldComponents().shortTextfield(placeHolder: TextLiterals.NickName.placeHolder, value: $textLimiter.value, isFocused: $isFocused)
                 .padding(.top, textFieldTopPadding)
             if textLimiter.hasReachedLimit {
                 withAnimation {
                     HStack {
-                        Text(warningMessage)
+                        Text(TextLiterals.NickName.warningMessage)
                             .foregroundColor(warningMessageColor)
                             .font(.system(size: warningMessageFontSize, weight: .semibold))
                         .padding(.top, warningMessageTopPadding)
@@ -53,7 +49,7 @@ struct NickNameView: View {
             Spacer()
             HStack {
                 Spacer()
-                ButtonComponents().smallButton(title: buttonTitle, disabledCondition: textLimiter.value.isEmpty, action: {})
+                ButtonComponents().smallButton(disabledCondition: textLimiter.value.isEmpty, action: {})
                     .offset(y: isFocused ? -self.keyboardHeightHelper.keyboardHeight : 0)
                     .animation(.easeIn(duration: 0.1), value: keyboardHeightHelper.keyboardHeight)
             }

--- a/Solidner/Views/Onboarding/OnboardingEndView.swift
+++ b/Solidner/Views/Onboarding/OnboardingEndView.swift
@@ -1,0 +1,28 @@
+//
+//  OnboardingEndView.swift
+//  Solidner
+//
+//  Created by 황지우2 on 2023/11/13.
+//
+
+import SwiftUI
+
+struct OnboardingEndView: View {
+    var body: some View {
+        viewBody()
+    }
+    func viewBody() -> some View {
+        return VStack(spacing: 0) {
+            Spacer()
+            OnboardingTitles(alignmentCase: .center, bigTitle: TextLiterals.OnboardingEnd.bigTitle, smallTitle: TextLiterals.OnboardingEnd.smallTitle)
+            Spacer()
+            ButtonComponents().bigButton(title: TextLiterals.OnboardingEnd.buttonTitle, disabledCondition: false, action: {})
+        }
+    }
+}
+
+struct OnboardingEndView_Previews: PreviewProvider {
+    static var previews: some View {
+        OnboardingEndView()
+    }
+}

--- a/Solidner/Views/Onboarding/OnboardingEndView.swift
+++ b/Solidner/Views/Onboarding/OnboardingEndView.swift
@@ -11,7 +11,7 @@ struct OnboardingEndView: View {
     var body: some View {
         viewBody()
     }
-    func viewBody() -> some View {
+    private func viewBody() -> some View {
         return VStack(spacing: 0) {
             Spacer()
             OnboardingTitles(alignmentCase: .center, bigTitle: TextLiterals.OnboardingEnd.bigTitle, smallTitle: TextLiterals.OnboardingEnd.smallTitle)

--- a/Solidner/Views/Onboarding/OnboardingTitles.swift
+++ b/Solidner/Views/Onboarding/OnboardingTitles.swift
@@ -14,11 +14,22 @@ struct OnboardingTitles: View {
     let bigTitleFontSize = CGFloat(28)
     let smallTitleFontSize = CGFloat(19)
     let smallTitleTopPadding = CGFloat(16)
-    @State var bigTitle: String = "언제부터 이유식을\n계획할까요?"
-    @State var smallTitle: String = "이미 이유식을 진행 중이라면\n처음 시작하신 날짜를 알려주세요"
+    let centerSmallTitleTopPadding = CGFloat(10)
+    @State var alignmentCase = AlignmentCase.leading
+    @State var bigTitle = ""
+    @State var smallTitle = ""
     @State var isSmallTitleExist = true
     var body: some View {
-        HStack {
+        switch alignmentCase {
+        case .leading :
+            leadingTitles()
+        case .center :
+            centerTitles()
+        }
+    }
+    
+    func leadingTitles () -> some View {
+        return HStack {
             VStack(alignment: .leading) {
                 Text(bigTitle)
                     .font(.system(size: bigTitleFontSize, weight: .bold))
@@ -34,10 +45,28 @@ struct OnboardingTitles: View {
             Spacer()
         }
     }
+    func centerTitles () -> some View {
+        return VStack(spacing: 0) {
+            Text(bigTitle)
+                .font(.system(size: bigTitleFontSize, weight: .bold))
+                .foregroundColor(bigTitleColor)
+                .multilineTextAlignment(.center)
+            Text(smallTitle)
+                .font(.system(size: smallTitleFontSize, weight: .medium))
+                .foregroundColor(smallTitleColor)
+                .padding(.top, centerSmallTitleTopPadding)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.leading, leadingPadding)
+    }
+    enum AlignmentCase {
+        case center
+        case leading
+    }
 }
 
 struct OnboardingTitles_Previews: PreviewProvider {
     static var previews: some View {
-        OnboardingTitles()
+        OnboardingTitles(bigTitle: "Dummy", smallTitle: "Dummy")
     }
 }

--- a/Solidner/Views/Onboarding/OnboardingTitles.swift
+++ b/Solidner/Views/Onboarding/OnboardingTitles.swift
@@ -15,10 +15,10 @@ struct OnboardingTitles: View {
     let smallTitleFontSize = CGFloat(19)
     let smallTitleTopPadding = CGFloat(16)
     let centerSmallTitleTopPadding = CGFloat(10)
-    @State var alignmentCase = AlignmentCase.leading
-    @State var bigTitle = ""
-    @State var smallTitle = ""
-    @State var isSmallTitleExist = true
+    var alignmentCase = AlignmentCase.leading
+    var bigTitle = ""
+    var smallTitle = ""
+    var isSmallTitleExist = true
     var body: some View {
         switch alignmentCase {
         case .leading :
@@ -28,7 +28,7 @@ struct OnboardingTitles: View {
         }
     }
     
-    func leadingTitles () -> some View {
+    private func leadingTitles () -> some View {
         return HStack {
             VStack(alignment: .leading) {
                 Text(bigTitle)
@@ -45,7 +45,7 @@ struct OnboardingTitles: View {
             Spacer()
         }
     }
-    func centerTitles () -> some View {
+    private func centerTitles () -> some View {
         return VStack(spacing: 0) {
             Text(bigTitle)
                 .font(.system(size: bigTitleFontSize, weight: .bold))
@@ -67,6 +67,6 @@ struct OnboardingTitles: View {
 
 struct OnboardingTitles_Previews: PreviewProvider {
     static var previews: some View {
-        OnboardingTitles(bigTitle: "Dummy", smallTitle: "Dummy")
+        OnboardingTitles()
     }
 }

--- a/Solidner/Views/Onboarding/OnboardingTitles.swift
+++ b/Solidner/Views/Onboarding/OnboardingTitles.swift
@@ -1,0 +1,43 @@
+//
+//  OnboardingTitles.swift
+//  Solidner
+//
+//  Created by 황지우2 on 2023/11/12.
+//
+
+import SwiftUI
+
+struct OnboardingTitles: View {
+    let bigTitleColor = Color(#colorLiteral(red: 0.0834152922, green: 0.0834152922, blue: 0.0834152922, alpha: 1))
+    let smallTitleColor = Color(#colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)).opacity(0.6)
+    let leadingPadding = CGFloat(4)
+    let bigTitleFontSize = CGFloat(28)
+    let smallTitleFontSize = CGFloat(19)
+    let smallTitleTopPadding = CGFloat(16)
+    @State var bigTitle: String = "언제부터 이유식을\n계획할까요?"
+    @State var smallTitle: String = "이미 이유식을 진행 중이라면\n처음 시작하신 날짜를 알려주세요"
+    @State var isSmallTitleExist = true
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading) {
+                Text(bigTitle)
+                    .font(.system(size: bigTitleFontSize, weight: .bold))
+                    .foregroundColor(bigTitleColor)
+                if isSmallTitleExist {
+                    Text(smallTitle)
+                        .font(.system(size: smallTitleFontSize, weight: .medium))
+                        .foregroundColor(smallTitleColor)
+                        .padding(.top, smallTitleTopPadding)
+                }
+            }
+            .padding(.leading, leadingPadding)
+            Spacer()
+        }
+    }
+}
+
+struct OnboardingTitles_Previews: PreviewProvider {
+    static var previews: some View {
+        OnboardingTitles()
+    }
+}

--- a/Solidner/Views/Onboarding/SoCuteNameView.swift
+++ b/Solidner/Views/Onboarding/SoCuteNameView.swift
@@ -12,10 +12,10 @@ struct SoCuteNameView: View {
     let delaySecond = 0.7
     let labelFontSize = 27.83
     let cuteNameMessageTopPadding = 10.0
-    @State var babyNickname = "찍무" + ","
-    @State var isNicknameAppear = false
-    @State var isMessageAppear = false
-    @State var isButtonAppear = false
+    @State private var babyNickname = "찍무" + ","
+    @State private var isNicknameAppear = false
+    @State private var isMessageAppear = false
+    @State private var isButtonAppear = false
     var body: some View {
         ZStack {
             backgroundColor.ignoresSafeArea()
@@ -40,7 +40,7 @@ struct SoCuteNameView: View {
             }
         }
     }
-    func labelView() -> some View {
+    private func labelView() -> some View {
         return VStack(spacing: 0) {
             Text(babyNickname)
                 .font(.system(size: labelFontSize, weight: .bold))
@@ -51,7 +51,7 @@ struct SoCuteNameView: View {
                 .padding(.top, cuteNameMessageTopPadding)
         }
     }
-    func buttonView() -> some View {
+    private func buttonView() -> some View {
         return VStack {
             Spacer()
             if isButtonAppear {

--- a/Solidner/Views/Onboarding/SoCuteNameView.swift
+++ b/Solidner/Views/Onboarding/SoCuteNameView.swift
@@ -1,0 +1,69 @@
+//
+//  SoCuteNameView.swift
+//  Solidner
+//
+//  Created by 황지우2 on 2023/11/13.
+//
+
+import SwiftUI
+
+struct SoCuteNameView: View {
+    let backgroundColor = Color(#colorLiteral(red: 0.8588235294, green: 0.9098039216, blue: 0.9568627451, alpha: 1))
+    let delaySecond = 0.7
+    let labelFontSize = 27.83
+    let cuteNameMessageTopPadding = 10.0
+    @State var babyNickname = "찍무" + ","
+    @State var isNicknameAppear = false
+    @State var isMessageAppear = false
+    @State var isButtonAppear = false
+    var body: some View {
+        ZStack {
+            backgroundColor.ignoresSafeArea()
+            labelView()
+            buttonView()
+        }
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now()) {
+                withAnimation(.easeInOut.delay(delaySecond)) {
+                    self.isNicknameAppear.toggle()
+                }
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now()+delaySecond) {
+                withAnimation(Animation.default.delay(delaySecond)) {
+                    self.isMessageAppear.toggle()
+                }
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3*delaySecond) {
+                withAnimation(.easeInOut.delay(delaySecond)) {
+                    self.isButtonAppear.toggle()
+                }
+            }
+        }
+    }
+    func labelView() -> some View {
+        return VStack(spacing: 0) {
+            Text(babyNickname)
+                .font(.system(size: labelFontSize, weight: .bold))
+                .foregroundColor(isNicknameAppear ? .black : .clear)
+            Text(TextLiterals.SoCuteName.cuteNameMessage)
+                .font(.system(size: labelFontSize, weight: .bold))
+                .foregroundColor(isMessageAppear ? .black : .clear)
+                .padding(.top, cuteNameMessageTopPadding)
+        }
+    }
+    func buttonView() -> some View {
+        return VStack {
+            Spacer()
+            if isButtonAppear {
+                ButtonComponents().bigButton(disabledCondition: false, action: {}, buttonColor: Color.white, titleColor: Color.black)
+                .transition(.opacity.animation(.easeIn))
+            }
+        }
+    }
+}
+
+struct SoCuteNameView_Previews: PreviewProvider {
+    static var previews: some View {
+        SoCuteNameView()
+    }
+}


### PR DESCRIPTION
## What I Did!

1.  뷰 컴포넌트 구성 
- Navigation Backbutton Header
- ButtonComponents(bigButton, smallButton, tinyButton)
- 기타 OnboardingView에서 사용되는 컴포넌트 (OnboardingView 그룹안에 있음)
- 유사한 컴포넌트 그룹은 같은 View Struct로 묶고, 해당 Struct의 하위 function으로 구분
- > ex) ButtonComponents.bigButton(~).

2.  Onboarding View 및 View 관련 로직 구현
- View는 외부에서 일괄적으로 같은 사이즈로 주는 패딩을 고려해서, viewBody() 함수로 패딩 적용될 영역을 따로 빼주었습니다.
- TextLimiterOB, KeyboardHeightHelperOB를 추가해서 각각 닉네임 텍스트 자수 제한과 키보드 키에 따라 올라가는 버튼을 구현했습니다.
- 뷰에서 사용된 String Literal들은 각 뷰별로 enum으로 분리해서 TextLiterals 파일에 넣어뒀습니다.

## Issue
#3 

close #N



## Review Point
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->



## Reference & Image
<img width="465" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team15-GearCo/assets/69354045/3a884e1c-3608-4205-bbb8-1d24856a924b">
-> 위와 같이 뷰는 헤더와 viewBody()의 VStack을 기본 구조로 구성해보았습니다.
- 헤더와 바디를 분리한 까닭은, 헤더에서의 외부 패딩과 바디에서의 외부 패딩이 값이 다르고, 바디 구성 요소들은 동일한 크기의 외부 패딩이 적용 될수 있을 것이라고 생각되서 입니다.
