### PR TITLE
Feat/#29 월간 플래닝 화면 제작

### DIFF
--- a/Solidner/Extension+/Date+.swift
+++ b/Solidner/Extension+/Date+.swift
@@ -76,6 +76,9 @@ extension Date {
         }
     }
     
+    
+    /// 현재 주차에 포함된 Date 객체들을 리스트로 반환합니다.
+    /// - Returns: 현재 주차의 날들을 Date형 리스트로 반환
     static func nowWeekDates() -> [Date] {
         let nowWeekOfMonth = Date().weekOfMonth
         let nowMonthDates = Date.nowMonthDates()
@@ -83,6 +86,10 @@ extension Date {
         return nowMonthDates.filter { $0.weekOfMonth == nowWeekOfMonth }
     }
     
+    
+    /// 파라미터로 받은 주차에 포함된 Date 객체를 리스트로 반환합니다.
+    /// - Parameter weekOfMonth: 원하는 주차 (Int)
+    /// - Returns: 입력된 주차에 포함된 날들을 Date형 리스트로 반환
     static func weekDates(_ weekOfMonth: Int) -> [Date] {
         let nowMonthDates = Date.nowMonthDates()
         
@@ -121,7 +128,7 @@ extension Date {
     
     /// weekDay의 한글 표현을 반환합니다.
     /// weekday는 1~7 사이의 Int형 정수입니다. (1 - 일요일, 2 - 월요일..)
-    /// Ex. 월, 화, 수, 목, 금, 토, 일
+    /// Ex. 일, 월, 화, 수, 목, 금, 토
     var weekDayKor: String {
         Weekday(rawValue: weekday)!.description
     }

--- a/Solidner/Extension+/Date+.swift
+++ b/Solidner/Extension+/Date+.swift
@@ -45,6 +45,49 @@ extension Date {
             Calendar.current.date(byAdding: .day, value: $0, to: startDate)
         }
     }
+    
+    /// 현재 날짜가 포함된 달의 모든 날짜의 Date 객체들을 반환합니다.
+    /// - Returns: 현재 달의 모든 날짜의 Date 객체를 포함한 리스트.
+    static func nowMonthDates() -> [Date] {
+        let now = Date()
+        let range = Calendar.current.range(of: .day, in: .month, for: now) ?? Range<Int>(1...1)
+        
+        let nowMonthFirstDay = Date.date(year: now.year, month: now.month, day: 1) ?? now
+        let nowMonthLastDay = Date.date(year: now.year, month: now.month, day: range.upperBound) ?? now
+        let resultDates = Date.range(from: nowMonthFirstDay, to: nowMonthLastDay)
+        
+        if resultDates.count <= 1 {
+            fatalError("시간 설정 오류. 기기의 시간을 확인해주세요.")
+        } else {
+            return resultDates
+        }
+    }
+    
+    /// 현재 날짜가 포함된 달이 몇 주차 까지 있는지 계산하여 Int형 리스트로 반환합니다.
+    /// - Returns: 현재 달의 주차를 Int형 리스트로 반환 (ex. `[1, 2, 3, 4, 5]`)
+    static func nowMonthWeeks() -> [Int] {
+        let now = Date()
+        let range = Calendar.current.range(of: .weekOfMonth, in: .month, for: now) ?? Range<Int>(1...1)
+        
+        if range.upperBound == 1 {
+            fatalError("시간 설정 오류. 기기의 시간을 확인해주세요.")
+        } else {
+            return Array(range.lowerBound...range.upperBound)
+        }
+    }
+    
+    static func nowWeekDates() -> [Date] {
+        let nowWeekOfMonth = Date().weekOfMonth
+        let nowMonthDates = Date.nowMonthDates()
+        
+        return nowMonthDates.filter { $0.weekOfMonth == nowWeekOfMonth }
+    }
+    
+    static func weekDates(_ index: Int) -> [Date] {
+        let nowMonthDates = Date.nowMonthDates()
+        
+        return nowMonthDates.filter { $0.weekOfMonth == index }
+    }
 
     func add(_ component: Calendar.Component, value: Int) -> Date {
         Calendar.current.date(byAdding: component, value: value, to: self)!

--- a/Solidner/Extension+/Date+.swift
+++ b/Solidner/Extension+/Date+.swift
@@ -53,7 +53,7 @@ extension Date {
         let range = Calendar.current.range(of: .day, in: .month, for: now) ?? Range<Int>(1...1)
         
         let nowMonthFirstDay = Date.date(year: now.year, month: now.month, day: 1) ?? now
-        let nowMonthLastDay = Date.date(year: now.year, month: now.month, day: range.upperBound) ?? now
+        let nowMonthLastDay = Date.date(year: now.year, month: now.month, day: range.upperBound - 1) ?? now
         let resultDates = Date.range(from: nowMonthFirstDay, to: nowMonthLastDay)
         
         if resultDates.count <= 1 {
@@ -72,7 +72,7 @@ extension Date {
         if range.upperBound == 1 {
             fatalError("시간 설정 오류. 기기의 시간을 확인해주세요.")
         } else {
-            return Array(range.lowerBound...range.upperBound)
+            return Array(range.lowerBound...range.upperBound - 1)
         }
     }
     
@@ -83,10 +83,10 @@ extension Date {
         return nowMonthDates.filter { $0.weekOfMonth == nowWeekOfMonth }
     }
     
-    static func weekDates(_ index: Int) -> [Date] {
+    static func weekDates(_ weekOfMonth: Int) -> [Date] {
         let nowMonthDates = Date.nowMonthDates()
         
-        return nowMonthDates.filter { $0.weekOfMonth == index }
+        return nowMonthDates.filter { $0.weekOfMonth == weekOfMonth }
     }
 
     func add(_ component: Calendar.Component, value: Int) -> Date {

--- a/Solidner/Extension+/View+.swift
+++ b/Solidner/Extension+/View+.swift
@@ -91,4 +91,32 @@ extension View {
                     .fill(color)
             }
     }
+    
+    /// View의 왼쪽을 radius값만큼 clip하여 반환합니다. (ex.`Rectangle().leftCornerRadius(10)` 처럼 사용)
+    /// - Parameter radius: radius값
+    /// - Returns: 왼쪽이 둥글어진 View
+    func leftCornerRadius(_ radius: CGFloat) -> some View {
+        self.cornerRadius(radius, corners: .topLeft)
+            .cornerRadius(radius, corners: .bottomLeft)
+    }
+    /// View의 오른쪽을 radius값만큼 clip하여 반환합니다. (ex.`Rectangle().rightCornerRadius(10)` 처럼 사용)
+    /// - Parameter radius: radius값
+    /// - Returns: 오른쪽이 둥글어진 View
+    func rightCornerRadius(_ radius: CGFloat) -> some View {
+        self.cornerRadius(radius, corners: .topRight)
+            .cornerRadius(radius, corners: .bottomRight)
+    }
+    func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
+        clipShape( RoundedCorner(radius: radius, corners: corners) )
+    }
+}
+
+struct RoundedCorner: Shape {
+    var radius: CGFloat = .infinity
+    var corners: UIRectCorner = .allCorners
+
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(roundedRect: rect, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
+        return Path(path.cgPath)
+    }
 }

--- a/Solidner/SolidnerApp.swift
+++ b/Solidner/SolidnerApp.swift
@@ -27,13 +27,14 @@ struct SolidnerApp: App {
     @StateObject private var userOB = UserOB()
     var body: some Scene {
         WindowGroup {
-            if isOnboardingOn {
-                AgreeToTermsView().environmentObject(userOB)
-            } else if isPlanEmpty {
-                StartPlanView()
-            } else {
-                PlanListView()
-            }
+//            if isOnboardingOn {
+//                AgreeToTermsView().environmentObject(userOB)
+//            } else if isPlanEmpty {
+//                StartPlanView()
+//            } else {
+//                PlanListView()
+//            }
+            MonthlyPlanningView()
             //SignInView().environmentObject(userOB)
         }
     }

--- a/Solidner/Views/Planning/Monthly/MonthlyPlanningView.swift
+++ b/Solidner/Views/Planning/Monthly/MonthlyPlanningView.swift
@@ -14,50 +14,97 @@ struct MonthlyPlanningView: View {
     private let lightGray = Color(#colorLiteral(red: 0.8797428608, green: 0.8797428012, blue: 0.8797428608, alpha: 1)) // #D9D9D9
     private let weekDayKorList = ["일", "월", "화", "수", "목", "금", "토"]
     
-    private let nowMonthDates = Date.nowMonthDates()
     private let nowMonthWeekNums = Date.nowMonthWeeks()
     
     var body: some View {
         VStack(spacing: 0) {
             // MARK: 임시로 대충 헤더 자리 비워두기
             Spacer().frame(height: 70)
-            calendarCurrentYearMonth.padding(.bottom, 15)
-            
-            VStack(spacing: 0) {
-                calendarWeekDayRow
-                ForEach(nowMonthWeekNums, id: \.self) { num in
-                    calendarDayNumberRow(weekOfMonth: num)
-                }
-                Text("\(nowMonthWeekNums.last!.description)")
-                Spacer()
-            }.background {
-                RoundedRectangle(cornerRadius: 12)
-                    .foregroundColor(.white)
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 0) {
+                    calendarCurrentYearMonth.padding(.bottom, 15)
+                    VStack(spacing: 0) {
+                        calendarWeekDayRow
+                        ForEach(nowMonthWeekNums, id: \.self) { num in
+                            calendarDayNumberRow(weekOfMonth: num)
+                            calendarNewIngredientRow(weekOfMonth: num)
+                        }
+                        Spacer()
+                    }.background {
+                        RoundedRectangle(cornerRadius: 12)
+                            .foregroundColor(.white)
+                    }
+                    Spacer()
+                }.padding(.horizontal, 16)
             }
+        }.background(Color(.lightGray))
+    }
+    
+    private func calendarNewIngredientRow(weekOfMonth: Int) -> some View {
+        let mainDaySectionWidth = screenWidth * (50/390)
+        let newIngredientRowHeight = screenWidth * (64/390)
+        let ingredientBarHeight = screenWidth * (22/390)
+        let rowHorizontalPadding = screenWidth * (4/390)
+        
+        let gapToFirstBar = screenWidth * (10/390)
+        let gapToSecondBar = screenWidth * (5/390)
+        
+        let barHorizontalPadding = screenWidth * (10/390)
+        
+
+        func ingredientBar() -> some View {
+            let barWidth = (mainDaySectionWidth*3) - (barHorizontalPadding*2)
+            return VStack {
+                HStack {
+                    Text("\(barHorizontalPadding)")
+                        .font(.system(size: 10))
+                        .bold()
+                        .foregroundColor(.white)
+                        .padding(.leading, 7)
+                    Spacer()
+                }
+            }.frame(width: barWidth, height: ingredientBarHeight)
+                .background {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.pink.opacity(0.5))
+                }.padding(.horizontal, barHorizontalPadding)
+        }
+        
+        return VStack(spacing: 0) {
+            Spacer().frame(height: gapToFirstBar)
+            HStack(spacing: 0) {
+                Spacer().frame(width: rowHorizontalPadding)
+                ingredientBar()
+                ingredientBar()
+                Spacer()
+            }.frame(height: ingredientBarHeight)
+            Spacer().frame(height: gapToSecondBar)
+            HStack(spacing: 0) {
+                ingredientBar()
+            }.frame(height: ingredientBarHeight)
             Spacer()
-        }.padding(.horizontal, 14)
-            .background(Color(.lightGray))
+        }.frame(height: newIngredientRowHeight)
     }
     
     private func calendarDayNumberRow(weekOfMonth: Int) -> some View {
         let mainDaySectionWidth = screenWidth * (50/390)
         let dayNumberRowFrameHeight = screenWidth * (60/390)
         let dayNumberGap = screenWidth * (6/390)
-        let rowHorizontalPadding = screenWidth * (6/390)
+        let rowHorizontalPadding = screenWidth * (4/390)
         let thisWeekDates: [Date] = Date.weekDates(weekOfMonth)
         
         func rowLeftEndSpacer() -> some View {
             if weekOfMonth == nowMonthWeekNums.first! {
                 return AnyView(Spacer())
             } else {
-                return AnyView(Spacer().frame(width: 6))
+                return AnyView(Spacer().frame(width: rowHorizontalPadding))
             }
         }
         func rowRightEndSpacer() -> some View {
             if weekOfMonth == nowMonthWeekNums.last! {
                 return AnyView(Spacer())
             } else {
-                return AnyView(Spacer().frame(width: 6))
+                return AnyView(Spacer().frame(width: rowHorizontalPadding))
             }
         }
         
@@ -81,7 +128,7 @@ struct MonthlyPlanningView: View {
     
     private var calendarWeekDayRow: some View {
         // TODO: color 및 font 수정
-        let mainHorizontalPadding = screenWidth * (6/390)
+        let mainHorizontalPadding = screenWidth * (4/390)
         let mainDaySectionWidth = screenWidth * (50/390)
         let weekDayRowFrameHeight = screenWidth * (25/390)
         
@@ -90,19 +137,19 @@ struct MonthlyPlanningView: View {
                 ForEach(weekDayKorList.indices, id: \.self) { i in
                     if i == 0 {
                         Text(weekDayKorList[i])
-                            .font(.system(size: 12))
+                            .font(.system(size: 10))
                             .bold()
                             .frame(width: mainDaySectionWidth)
-//                            .padding(.leading, mainHorizontalPadding)
+                            .padding(.leading, mainHorizontalPadding)
                     } else if i == 6 {
                         Text(weekDayKorList[i])
-                            .font(.system(size: 12))
+                            .font(.system(size: 10))
                             .bold()
                             .frame(width: mainDaySectionWidth)
-//                            .padding(.trailing, mainHorizontalPadding)
+                            .padding(.trailing, mainHorizontalPadding)
                     } else {
                         Text(weekDayKorList[i])
-                            .font(.system(size: 12))
+                            .font(.system(size: 10))
                             .bold()
                             .frame(width: mainDaySectionWidth)
                     }

--- a/Solidner/Views/Planning/Monthly/MonthlyPlanningView.swift
+++ b/Solidner/Views/Planning/Monthly/MonthlyPlanningView.swift
@@ -8,11 +8,15 @@
 import SwiftUI
 
 struct MonthlyPlanningView: View {
-    let screenWidth = UIScreen.main.bounds.size.width
-    let screenHeight = UIScreen.main.bounds.size.height
+    private let screenWidth = UIScreen.main.bounds.size.width
+    private let screenHeight = UIScreen.main.bounds.size.height
     
-    let lightGray = Color(#colorLiteral(red: 0.8797428608, green: 0.8797428012, blue: 0.8797428608, alpha: 1)) // #D9D9D9
-    let weekDayKorList = ["일", "월", "화", "수", "목", "금", "토"]
+    private let lightGray = Color(#colorLiteral(red: 0.8797428608, green: 0.8797428012, blue: 0.8797428608, alpha: 1)) // #D9D9D9
+    private let weekDayKorList = ["일", "월", "화", "수", "목", "금", "토"]
+    
+    private let nowMonthDates = Date.nowMonthDates()
+    private let nowMonthWeekNum = Date.nowMonthWeeks()
+    private let nowWeekDates = Date.nowWeekDates()
     
     var body: some View {
         VStack(spacing: 0) {
@@ -22,6 +26,8 @@ struct MonthlyPlanningView: View {
             
             VStack(spacing: 0) {
                 calendarWeekDayRow
+                calendarDayNumberRow()
+
                 Spacer()
             }.background {
                 RoundedRectangle(cornerRadius: 12)
@@ -32,26 +38,63 @@ struct MonthlyPlanningView: View {
             .background(Color(.lightGray))
     }
     
+    private func calendarDayNumberRow() -> some View {
+        let mainDaySectionWidth = screenWidth * (50/390)
+        let dayNumberRowFrameHeight = screenWidth * (60/390)
+        let dayNumberGap = screenWidth * (6/390)
+        let number: [Int] = [1, 2, 3, 4, 5, 6, 7]
+        
+        return VStack(spacing: 0) {
+            HStack(alignment: .center, spacing: 0) {
+                ForEach(number.indices, id: \.self) { i in
+                    VStack(spacing: 0) {
+                        Text("\(number[i])")
+                            .font(.system(size: 11))
+                            .padding(.bottom, dayNumberGap)
+                        Text("\(number[i])")
+                            .font(.system(size: 17))
+                    }.frame(width: mainDaySectionWidth)
+                }
+            }.frame(height: dayNumberRowFrameHeight)
+            calendarDivider
+        }
+    }
+    
     private var calendarWeekDayRow: some View {
+        // TODO: color 및 font 수정
         let mainHorizontalPadding = screenWidth * (6/390)
         let mainDaySectionWidth = screenWidth * (50/390)
+        let weekDayRowFrameHeight = screenWidth * (25/390)
         
-        return HStack(alignment: .center, spacing: 0) {
-            ForEach(weekDayKorList.indices) { i in
-                if i == 0 {
-                    Text(weekDayKorList[i])
-                        .frame(width: mainDaySectionWidth)
-                        .padding(.leading, mainHorizontalPadding)
-                } else if i == 6 {
-                    Text(weekDayKorList[i])
-                        .frame(width: mainDaySectionWidth)
-                        .padding(.trailing, mainHorizontalPadding)
-                } else {
-                    Text(weekDayKorList[i])
-                        .frame(width: mainDaySectionWidth)
+        return VStack(spacing: 0) {
+            HStack(alignment: .center, spacing: 0) {
+                ForEach(weekDayKorList.indices, id: \.self) { i in
+                    if i == 0 {
+                        Text(weekDayKorList[i])
+                            .font(.system(size: 12))
+                            .bold()
+                            .frame(width: mainDaySectionWidth)
+//                            .padding(.leading, mainHorizontalPadding)
+                    } else if i == 6 {
+                        Text(weekDayKorList[i])
+                            .font(.system(size: 12))
+                            .bold()
+                            .frame(width: mainDaySectionWidth)
+//                            .padding(.trailing, mainHorizontalPadding)
+                    } else {
+                        Text(weekDayKorList[i])
+                            .font(.system(size: 12))
+                            .bold()
+                            .frame(width: mainDaySectionWidth)
+                    }
                 }
-            }
-        }.frame(height: 25)
+            }.frame(height: weekDayRowFrameHeight)
+            calendarDivider
+        }
+    }
+    
+    private var calendarDivider: some View {
+        Rectangle().frame(height: 1).foregroundColor(.black)
     }
     
     private var calendarCurrentYearMonth: some View {

--- a/Solidner/Views/Planning/Monthly/MonthlyPlanningView.swift
+++ b/Solidner/Views/Planning/Monthly/MonthlyPlanningView.swift
@@ -15,8 +15,7 @@ struct MonthlyPlanningView: View {
     private let weekDayKorList = ["일", "월", "화", "수", "목", "금", "토"]
     
     private let nowMonthDates = Date.nowMonthDates()
-    private let nowMonthWeekNum = Date.nowMonthWeeks()
-    private let nowWeekDates = Date.nowWeekDates()
+    private let nowMonthWeekNums = Date.nowMonthWeeks()
     
     var body: some View {
         VStack(spacing: 0) {
@@ -26,8 +25,10 @@ struct MonthlyPlanningView: View {
             
             VStack(spacing: 0) {
                 calendarWeekDayRow
-                calendarDayNumberRow()
-
+                ForEach(nowMonthWeekNums, id: \.self) { num in
+                    calendarDayNumberRow(weekOfMonth: num)
+                }
+                Text("\(nowMonthWeekNums.last!.description)")
                 Spacer()
             }.background {
                 RoundedRectangle(cornerRadius: 12)
@@ -38,23 +39,41 @@ struct MonthlyPlanningView: View {
             .background(Color(.lightGray))
     }
     
-    private func calendarDayNumberRow() -> some View {
+    private func calendarDayNumberRow(weekOfMonth: Int) -> some View {
         let mainDaySectionWidth = screenWidth * (50/390)
         let dayNumberRowFrameHeight = screenWidth * (60/390)
         let dayNumberGap = screenWidth * (6/390)
-        let number: [Int] = [1, 2, 3, 4, 5, 6, 7]
+        let rowHorizontalPadding = screenWidth * (6/390)
+        let thisWeekDates: [Date] = Date.weekDates(weekOfMonth)
+        
+        func rowLeftEndSpacer() -> some View {
+            if weekOfMonth == nowMonthWeekNums.first! {
+                return AnyView(Spacer())
+            } else {
+                return AnyView(Spacer().frame(width: 6))
+            }
+        }
+        func rowRightEndSpacer() -> some View {
+            if weekOfMonth == nowMonthWeekNums.last! {
+                return AnyView(Spacer())
+            } else {
+                return AnyView(Spacer().frame(width: 6))
+            }
+        }
         
         return VStack(spacing: 0) {
             HStack(alignment: .center, spacing: 0) {
-                ForEach(number.indices, id: \.self) { i in
+                rowLeftEndSpacer()
+                ForEach(thisWeekDates, id: \.self) { date in
                     VStack(spacing: 0) {
-                        Text("\(number[i])")
+                        Text("\(date.day)")
                             .font(.system(size: 11))
                             .padding(.bottom, dayNumberGap)
-                        Text("\(number[i])")
+                        Text("\(date.day)")
                             .font(.system(size: 17))
                     }.frame(width: mainDaySectionWidth)
                 }
+                rowRightEndSpacer()
             }.frame(height: dayNumberRowFrameHeight)
             calendarDivider
         }

--- a/Solidner/Views/Planning/Monthly/MonthlyPlanningView.swift
+++ b/Solidner/Views/Planning/Monthly/MonthlyPlanningView.swift
@@ -16,6 +16,18 @@ struct MonthlyPlanningView: View {
     
     private let nowMonthWeekNums = Date.nowMonthWeeks()
     
+    // Dummy struct
+    struct planData {
+        var startDate: Int
+        var endDate: Int
+    }
+    let plan: [planData] =
+    [planData(startDate: 1, endDate: 3),
+    planData(startDate: 3, endDate: 5),
+    planData(startDate: 5, endDate: 7),
+    planData(startDate: 12, endDate: 15)]
+
+    
     var body: some View {
         VStack(spacing: 0) {
             // MARK: 임시로 대충 헤더 자리 비워두기
@@ -35,7 +47,7 @@ struct MonthlyPlanningView: View {
                             .foregroundColor(.white)
                     }
                     Spacer()
-                }.padding(.horizontal, 16)
+                }.clipped().padding(.horizontal, 16)
             }
         }.background(Color(.lightGray))
     }
@@ -51,7 +63,6 @@ struct MonthlyPlanningView: View {
         
         let barHorizontalPadding = screenWidth * (10/390)
         
-
         func ingredientBar() -> some View {
             let barWidth = (mainDaySectionWidth*3) - (barHorizontalPadding*2)
             return VStack {
@@ -65,8 +76,9 @@ struct MonthlyPlanningView: View {
                 }
             }.frame(width: barWidth, height: ingredientBarHeight)
                 .background {
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(Color.pink.opacity(0.5))
+                    Rectangle()
+                        .leftCornerRadius(4)
+                        .foregroundColor(Color.pink.opacity(0.5))
                 }.padding(.horizontal, barHorizontalPadding)
         }
         
@@ -78,9 +90,12 @@ struct MonthlyPlanningView: View {
                 ingredientBar()
                 Spacer()
             }.frame(height: ingredientBarHeight)
+                .frame(maxWidth: 358)
             Spacer().frame(height: gapToSecondBar)
             HStack(spacing: 0) {
+                Spacer().frame(width: rowHorizontalPadding)
                 ingredientBar()
+                Spacer()
             }.frame(height: ingredientBarHeight)
             Spacer()
         }.frame(height: newIngredientRowHeight)

--- a/Solidner/Views/Planning/Monthly/MonthlyPlanningView.swift
+++ b/Solidner/Views/Planning/Monthly/MonthlyPlanningView.swift
@@ -21,12 +21,14 @@ struct MonthlyPlanningView: View {
         var startDate: Int
         var endDate: Int
     }
-    let plan: [planData] =
+    let plans: [planData] =
     [planData(startDate: 1, endDate: 3),
     planData(startDate: 3, endDate: 5),
+    planData(startDate: 2, endDate: 4),
     planData(startDate: 5, endDate: 7),
     planData(startDate: 12, endDate: 15)]
-
+    
+    @State private var reducePlans: [(planData, BarPosition)] = []
     
     var body: some View {
         VStack(spacing: 0) {
@@ -50,6 +52,10 @@ struct MonthlyPlanningView: View {
                 }.clipped().padding(.horizontal, 16)
             }
         }.background(Color(.lightGray))
+            .onAppear {
+                reducePlans = reducePlanData(plans: plans)
+                print(reducePlans)
+            }
     }
     
     private func calendarNewIngredientRow(weekOfMonth: Int) -> some View {
@@ -183,6 +189,47 @@ struct MonthlyPlanningView: View {
             Text("2023년 10월").font(.title).bold()
             Spacer()
         }
+    }
+}
+
+extension MonthlyPlanningView {
+    enum BarPosition: Int {
+        case first = 1
+        case second = 2
+    }
+    
+    private func reducePlanData(plans: [planData]) -> [(planData, BarPosition)] {
+        let nowMonthDates = Date.nowMonthDates()
+        let lastDateNum = nowMonthDates.last!.day
+        var dict = Dictionary(uniqueKeysWithValues: (1...lastDateNum).map { ($0, 0) })
+        
+        var result: [(planData, BarPosition)] = []
+        
+        for plan in plans {
+            var isPlanAccepted = true
+            var isFirstBar = true
+            
+            for i in Range<Int>(plan.startDate...plan.endDate) {
+                if dict[i] == 2 {
+                    isPlanAccepted = false
+                } else if dict[i] == 1 {
+                    isFirstBar = false
+                }
+            }
+            
+            if isPlanAccepted {
+                for i in Range<Int>(plan.startDate...plan.endDate) {
+                    dict[i]! += 1
+                }
+                if isFirstBar {
+                    result.append((plan, .first))
+                } else {
+                    result.append((plan, .second))
+                }
+            }
+        }
+        
+        return result
     }
 }
 

--- a/Solidner/Views/Planning/Monthly/MonthlyPlanningView.swift
+++ b/Solidner/Views/Planning/Monthly/MonthlyPlanningView.swift
@@ -23,15 +23,15 @@ struct MonthlyPlanningView: View {
     }
     // MARK: 이전 달의 데이터와 이후 달의 데이터는 -2, 33 등과 같이 표현할 것.
     let plans: [planData] =
-    [planData(startDate: 1, endDate: 2),
-     planData(startDate: 3, endDate: 4),
-     planData(startDate: 2, endDate: 4),
-     planData(startDate: 5, endDate: 7),
-     planData(startDate: 8, endDate: 10),
-     planData(startDate: 9, endDate: 11),
-     planData(startDate: 13, endDate: 14),
-     planData(startDate: 26, endDate: 27),
-     planData(startDate: 29, endDate: 30),
+    [planData(startDate: 0, endDate: 2),
+//     planData(startDate: 3, endDate: 4),
+//     planData(startDate: 2, endDate: 4),
+//     planData(startDate: 5, endDate: 7),
+//     planData(startDate: 8, endDate: 10),
+//     planData(startDate: 9, endDate: 11),
+//     planData(startDate: 13, endDate: 14),
+//     planData(startDate: 26, endDate: 27),
+//     planData(startDate: 29, endDate: 30),
 //     planData(startDate: -1, endDate: 1),
 //     planData(startDate: 29, endDate: 31),
      planData(startDate: 12, endDate: 15)]
@@ -62,7 +62,6 @@ struct MonthlyPlanningView: View {
         }.background(Color(.lightGray))
             .onAppear {
                 reducedPlans = reducePlanData(plans: plans)
-                print(reducedPlans)
             }
     }
     
@@ -76,6 +75,7 @@ struct MonthlyPlanningView: View {
         let gapToSecondBar = screenWidth * (5/390)
         
         let barHorizontalPadding = screenWidth * (10/390)
+        let endPadding = barHorizontalPadding + rowHorizontalPadding
         
         let plansInWeek: [(data: planData, position: BarPosition)]
         = reducePlanDataInWeek(weekOfMonth: weekOfMonth, reducedPlans: reducedPlans)
@@ -91,8 +91,9 @@ struct MonthlyPlanningView: View {
         let dayNumsInWeek: [Int] = weekDates.map{ $0.day }
         let monthDates = Date.nowMonthDates()
         
+        
         // 바 길이 계산
-        func calculateBarWidth(plan: planData, isBarFromEnd: inout (left: Bool, right: Bool)) -> CGFloat {
+        func calculateBarWidth(plan: planData, isBarFromEnd: (left: Bool, right: Bool)) -> CGFloat {
             let cycleGap: CGFloat = CGFloat(plan.endDate - plan.startDate + 1)
             var result: CGFloat = 0
             
@@ -100,15 +101,13 @@ struct MonthlyPlanningView: View {
                 dayNumsInWeek.contains(plan.endDate) {
                 result = (mainDaySectionWidth * cycleGap) - (barHorizontalPadding * 2)
             } else if dayNumsInWeek.first! > plan.startDate {
-                isBarFromEnd.left = true
                 if dayNumsInWeek.first! == 1 {  // 1일 이전부터 이어지는 바
                     let weekDay = CGFloat(weekDates.first!.weekday)  // 요일
-                    result = (mainDaySectionWidth * weekDay) - barHorizontalPadding + rowHorizontalPadding
+                    result = (mainDaySectionWidth * weekDay) - barHorizontalPadding * 2 + endPadding
                 } else {
-                    result = (mainDaySectionWidth * cycleGap) - barHorizontalPadding + rowHorizontalPadding
+                    result = (mainDaySectionWidth * cycleGap) - barHorizontalPadding * 2 + endPadding
                 }
             } else if dayNumsInWeek.last! < plan.endDate {
-                isBarFromEnd.right = true
                 if dayNumsInWeek.last! == monthDates.last!.day {    // 월말 이후까지 이어지는 바
                     let weekDay = weekDates.first!.weekday  // 요일
                     let dayGap = CGFloat(7 - weekDay + 1)
@@ -124,36 +123,32 @@ struct MonthlyPlanningView: View {
         }
         
         // 재료 바 view return
-        func ingredientBar(plan: planData, index: Int, isBarFromEnd: inout (left: Bool, right: Bool)) -> some View {
-//            var isBarFromEnd: (left: Bool, right: Bool) = (false, false)
+        func ingredientBar(plan: planData, index: Int, isBarFromEnd: (left: Bool, right: Bool)) -> some View {
             // MARK: 오류나면 다시볼 것
-            let barWidth: CGFloat = calculateBarWidth(plan: plan, isBarFromEnd: &isBarFromEnd)
+            let barWidth: CGFloat = calculateBarWidth(plan: plan, isBarFromEnd: isBarFromEnd)
             let barRadius: CGFloat = 4
                         
-            return HStack(spacing: 0) {
-                VStack(spacing: 0) {
-                    HStack(spacing: 0) {
-                        Text("고기고기고기")
-                            .font(.system(size: 10))
-                            .bold()
-                            .foregroundColor(.white)
-                            .padding(.leading, 7)
-                        Spacer()
-                    }
-                }.frame(width: barWidth, height: ingredientBarHeight)
-                .background {
-                    Rectangle()
-                        .foregroundColor(Color.pink.opacity(0.5))
-                        .if(!isBarFromEnd.left) { view in
-                            view.leftCornerRadius(barRadius)
-                        }.if(!isBarFromEnd.right) { view in
-                            view.rightCornerRadius(barRadius)
-                        }
+            return VStack(spacing: 0) {
+                HStack(spacing: 0) {
+                    Text("고기고기고기")
+                        .font(.system(size: 10))
+                        .bold()
+                        .foregroundColor(.white)
+                        .padding(.leading, 7)
+                    Spacer()
                 }
+            }.frame(width: barWidth, height: ingredientBarHeight)
+            .background {
+                Rectangle()
+                    .foregroundColor(Color.pink.opacity(0.5))
+                    .if(!isBarFromEnd.left) { view in
+                        view.leftCornerRadius(barRadius)
+                    }.if(!isBarFromEnd.right) { view in
+                        view.rightCornerRadius(barRadius)
+                    }
             }
         }
         
-        let endPadding = barHorizontalPadding + rowHorizontalPadding
         func barLeftPadding(plans: [planData], index: Int, isBarFromEnd: (left: Bool, right: Bool)) -> some View {
             
             switch plans.count {
@@ -161,6 +156,7 @@ struct MonthlyPlanningView: View {
                 return AnyView(Spacer())
             case 1: // 한 줄에 plan이 하나일 때
                 if isBarFromEnd.left {  // 왼쪽으로 붙여야 하면
+                    print(isBarFromEnd)
                     return AnyView(EmptyView())
                 } else if isBarFromEnd.right {  // 오른쪽으로 붙여야 하면
                     return AnyView(Spacer())
@@ -209,7 +205,6 @@ struct MonthlyPlanningView: View {
                     return AnyView(Spacer().frame(width: width))
                 }
             }
-                
         }
         func barRightPadding(plans: [planData], index: Int, isBarFromEnd: (left: Bool, right: Bool)) -> some View {
             switch plans.count {
@@ -240,15 +235,26 @@ struct MonthlyPlanningView: View {
             }
         }
         
+        func calculateIsBarFromEnd(plan: planData) -> (Bool, Bool) {
+            var result: (left: Bool, right: Bool) = (false, false)
+            if dayNumsInWeek.first! > plan.startDate {
+                result.left = true
+            } else if dayNumsInWeek.last! < plan.endDate {
+                result.right = true
+            }
+            
+            return result
+        }
+        
         // MARK: 재료 바를 포함한 한 줄 return
         return VStack(spacing: 0) {
             Spacer().frame(height: gapToFirstBar)
             
             HStack(spacing: 0) {
                 ForEach(Array(plansInWeekFirstLine.indices), id: \.self) { i in
-                    var isBarFromEnd: (left: Bool, right: Bool) = (false, false)
+                    let isBarFromEnd: (Bool, Bool) = calculateIsBarFromEnd(plan: plansInWeekFirstLine[i])
                     barLeftPadding(plans: plansInWeekFirstLine, index: i, isBarFromEnd: isBarFromEnd)
-                    ingredientBar(plan: plansInWeekFirstLine[i], index: i, isBarFromEnd: &isBarFromEnd)
+                    ingredientBar(plan: plansInWeekFirstLine[i], index: i, isBarFromEnd: isBarFromEnd)
                     barRightPadding(plans: plansInWeekFirstLine, index: i, isBarFromEnd: isBarFromEnd)
                 }
             }.frame(height: ingredientBarHeight)
@@ -257,9 +263,10 @@ struct MonthlyPlanningView: View {
             
             HStack(spacing: 0) {
                 ForEach(Array(plansInWeekSecondLine.indices), id: \.self) { i in
-                    var isBarFromEnd: (left: Bool, right: Bool) = (false, false)
+                    let isBarFromEnd: (Bool, Bool) = calculateIsBarFromEnd(plan: plansInWeekFirstLine[i])
+                    
                     barLeftPadding(plans: plansInWeekSecondLine, index: i, isBarFromEnd: isBarFromEnd)
-                    ingredientBar(plan: plansInWeekSecondLine[i], index: i, isBarFromEnd: &isBarFromEnd)
+                    ingredientBar(plan: plansInWeekSecondLine[i], index: i, isBarFromEnd: isBarFromEnd)
                     barRightPadding(plans: plansInWeekSecondLine, index: i, isBarFromEnd: isBarFromEnd)
                 }
             }.frame(height: ingredientBarHeight)
@@ -399,7 +406,7 @@ extension MonthlyPlanningView {
         let dayNumsInWeek: [Int] = Date.weekDates(weekOfMonth).map{ $0.day }
         var result: [(planData, BarPosition)] = []
         
-        for plan in reducedPlans {
+        for plan in reducedPlans.sorted(by: { $0.0.startDate < $1.0.startDate }) {
             if dayNumsInWeek.contains(plan.first.startDate) ||
                 dayNumsInWeek.contains(plan.first.endDate) {
                 result.append(plan)


### PR DESCRIPTION
## What I Did!
<!-- 작업 내용과 참고 스크린샷 첨부 -->

오늘도 내가 해냄!
<img width="120" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team15-GearCo/assets/82885362/1670fb21-aab3-4864-b88c-c22eb4364633">


* [x] calendarNewIngredientRow - 블록 두 줄을 포함한 Row 함수 작성 및 패딩값 조절
* [x] calculateBarWidth - 블록 길이 계산 함수 작성
* [x] ingredientBar - 하나의 블록을 return하는 함수
* [x] barLeftPadding, barRightPadding - 블록의 왼쪽, 오른쪽 공간 너비 계산
* [x] calculateIsBarFromEnd - 블록이 한 쪽 끝에서 이어지는 지 여부 확인
* [x] reducePlanData - 월간 plan 리스트에서 캘린더에 표현될 수 있는 일정을 필터링하고 정렬.
* [x] reducePlanDataInWeek - 위 함수에서 필터링된 plan 중, 현재 주차에 표현되어야 할 plan을 다시 필터링



## Issue

<!-- 참고할 Issue와 연관된 Issue를 적어주세요. (ex. #1, close #2) -->

close #29 



## Review Point
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->

- 아래와 같이 Date Extension 함수가 몇 가지 추가되었습니다.
Documentation을 달아 두었으니 참고 바랍니다.
https://github.com/DeveloperAcademy-POSTECH/MacC-Team15-GearCo/blob/ca98ac944bb516e7ef12199704d18a7f7eebc0b1/Solidner/Extension%2B/Date%2B.swift#L49-L64
  
- 아래와 같이 View Extension이 추가되었습니다. 
한 쪽(좌측, 우측) 에만 Radius를 달고 싶을 때 사용 바랍니다.
Documentation을 달아 두었으니 참고 바랍니다.
https://github.com/DeveloperAcademy-POSTECH/MacC-Team15-GearCo/blob/ca98ac944bb516e7ef12199704d18a7f7eebc0b1/Solidner/Extension%2B/View%2B.swift#L95-L108

- MontlyPlanningView의 여러 로직을 포함한 화면 작업이 완료되었습니다.
로직이 상당히 복잡하니, 추후 이해가 필요하다면 직접 설명해드리도록 하고, 가급적 코드를 수정하지 않기 바랍니다.
추가로, 추후 실제 plan 데이터를 이용해 view를 그리게 된다면, 아래와 같은 형태로 plan의 데이터를 재가공하여 사용하는 것이 좋아 보입니다.
(나중에 제가 하겠습니다..)
https://github.com/DeveloperAcademy-POSTECH/MacC-Team15-GearCo/blob/ca98ac944bb516e7ef12199704d18a7f7eebc0b1/Solidner/Views/Planning/Monthly/MonthlyPlanningView.swift#L20-L49


## Reference & Image

<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team15-GearCo/assets/82885362/f7a1cd2f-69d4-4888-af62-eb9219c8f22d" width="30%"/>

