### PR TITLE
[Feat/#78]: 월간 계획 화면 빈 날짜 클릭 시 플랜 추가 기능 및 상세 화면 연결

### DIFF
--- a/Solidner/Views/Planning/Monthly/MonthlyPlanningView.swift
+++ b/Solidner/Views/Planning/Monthly/MonthlyPlanningView.swift
@@ -372,24 +372,34 @@ struct MonthlyPlanningView: View {
                 rowLeftEndSpacer()
                 ForEach(thisWeekDates, id: \.self) { date in
                     let isToday = (date.day == Date().day && date.month == Date().month && date.year == Date().year)
-                    VStack(spacing: 0) {
-                        if isToday {
-                            Circle()
-                                .scaledToFit()
-                                .frame(width: todayCircleDiameter)
-                                .foregroundStyle(Color.defaultText_wh)
-                                .frame(height: solidDayNumberFrameHeight)
-                                .padding(.bottom, dayNumberGap)
+                    
+                    NavigationLink {
+                        let mealPlans = mealPlansOB.getMealPlans(in: date)
+                        if mealPlans.count != .zero {
+                            DailyPlanListView(date: date, mealPlans: mealPlans)
                         } else {
-                            Text("\(Date.componentsBetweenDates(from: user.solidStartDate, to: date).day!)")
-                                .weekDisplayFont1()
-                                .foregroundStyle(Color.tertinaryText)
-                                .frame(height: solidDayNumberFrameHeight)
-                                .padding(.bottom, dayNumberGap)
+                            MealDetailView(startDate: date, cycleGap: user.planCycleGap)
                         }
-                        Text("\(date.day)")
-                            .dayDisplayFont2()
-                            .foregroundStyle(isToday ? Color.defaultText_wh : Color.tertinaryText)
+                    } label: {
+                        VStack(spacing: 0) {
+                            if isToday {
+                                Circle()
+                                    .scaledToFit()
+                                    .frame(width: todayCircleDiameter)
+                                    .foregroundStyle(Color.defaultText_wh)
+                                    .frame(height: solidDayNumberFrameHeight)
+                                    .padding(.bottom, dayNumberGap)
+                            } else {
+                                Text("\(Date.componentsBetweenDates(from: user.solidStartDate, to: date).day!)")
+                                    .weekDisplayFont1()
+                                    .foregroundStyle(Color.tertinaryText)
+                                    .frame(height: solidDayNumberFrameHeight)
+                                    .padding(.bottom, dayNumberGap)
+                            }
+                            Text("\(date.day)")
+                                .dayDisplayFont2()
+                                .foregroundStyle(isToday ? Color.defaultText_wh : Color.tertinaryText)
+                        }
                     }.frame(width: mainDaySectionWidth)
                         .if(isToday) { view in
                             view.background {


### PR DESCRIPTION
## What I Did!
<!-- 작업 내용과 참고 스크린샷 첨부 -->

* [x] 빈 날짜를 눌렀을 때 플랜 추가 기능
* [x] 이미 계획이 있는 날짜를 눌렀을 때 하루 식단 상세 화면으로
* [ ] 그리고 계획 수정
=>  올리가 작업 중

## Issue

<!-- 참고할 Issue와 연관된 Issue를 적어주세요. (ex. #1, close #2) -->

close #78 

## Review Point
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->

