### PR TITLE
[Feat/#88] 재료 추가 화면 여러 작업들 - 2

### DIFF
--- a/Solidner/Views/Planning/AddPlan/AddIngredientBigDivision.swift
+++ b/Solidner/Views/Planning/AddPlan/AddIngredientBigDivision.swift
@@ -57,16 +57,19 @@ struct IngredientsBigDivision: View {
     
     let viewType: MealOB.IngredientTestType
     let initialSelectedIngredients: [Int]   // selectedIngredients 복사. 테스트 재료 추가 화면에서 정상적으로 보일 수 있게.
+    let scrollID: ScrollID
     
     init(case divisionCase: DivisionCase, ingredients selectedIngredients: Binding<[Int]>,
          initSelected initialSelectedIngredients: [Int], viewType: MealOB.IngredientTestType,
-         ingredientUseCount: Binding<[Int: Int]>) {
+         ingredientUseCount: Binding<[Int: Int]>, scrollID: ScrollID) {
         self.divisionCase = divisionCase
         self.viewType = viewType
         self._ingredientUseCount = ingredientUseCount
         
         self._selectedIngredients = selectedIngredients
         self.initialSelectedIngredients = initialSelectedIngredients
+        self.scrollID = scrollID
+        
         var states: [IngredientType: Bool] = [:]
         for type in IngredientType.allCases {
             states[type] = false
@@ -135,7 +138,7 @@ extension IngredientsBigDivision {
             TitleAndHintView(title: divisionCase.rawValue, hint: explainText)
             Spacer().frame(height: divisionSubTitleBottomSpace)
             
-            ForEach(IngredientType.allCases, id: \.self) { type in
+            ForEach(Array(IngredientType.allCases.enumerated()), id: \.element) { index, type in
                 HStack(spacing: 0) {
                     Text(type.description)
                         .font(.system(size: 19, weight: .semibold))
@@ -159,7 +162,7 @@ extension IngredientsBigDivision {
                     withAnimation(.spring()) {
                         toggleFoldState(foldStateList: &foldStates, type: type)
                     }
-                }
+                }.id(divisionCase == .먹을수있는재료 ? scrollID.namespaces1[index] : scrollID.namespaces2[index])
                 
                 if foldStates[type]! {
                     Divider()

--- a/Solidner/Views/Planning/AddPlan/AddIngredientBigDivision.swift
+++ b/Solidner/Views/Planning/AddPlan/AddIngredientBigDivision.swift
@@ -54,13 +54,13 @@ struct IngredientsBigDivision: View {
     let viewType: MealOB.IngredientTestType
     let initialSelectedIngredients: [Int]   // selectedIngredients 복사. 테스트 재료 추가 화면에서 정상적으로 보일 수 있게.
     
-    init(case divisionCase: DivisionCase, ingredients selectedIngredients: Binding<[Int]>, viewType: MealOB.IngredientTestType, ingredientUseCount: Binding<[Int: Int]>) {
+    init(case divisionCase: DivisionCase, ingredients selectedIngredients: Binding<[Int]>, initSelected initialSelectedIngredients: [Int], viewType: MealOB.IngredientTestType, ingredientUseCount: Binding<[Int: Int]>) {
         self.divisionCase = divisionCase
         self.viewType = viewType
         self._ingredientUseCount = ingredientUseCount
         
         self._selectedIngredients = selectedIngredients
-        self.initialSelectedIngredients = selectedIngredients.wrappedValue
+        self.initialSelectedIngredients = initialSelectedIngredients
         var states: [IngredientType: Bool] = [:]
         for type in IngredientType.allCases {
             states[type] = false

--- a/Solidner/Views/Planning/AddPlan/AddIngredientBigDivision.swift
+++ b/Solidner/Views/Planning/AddPlan/AddIngredientBigDivision.swift
@@ -78,6 +78,12 @@ struct IngredientsBigDivision: View {
         foldStateList[type]?.toggle()
     }
     
+    private func filterAndSortIngredients(by searchTerm: String, from values: [Ingredient]) -> [Ingredient] {
+        // 재료 name으로 filtering 및 sorting
+        return values.filter { $0.name.localizedCaseInsensitiveContains(searchTerm) }
+                     .sorted { $0.name < $1.name }
+    }
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             switch divisionCase {
@@ -99,8 +105,30 @@ struct IngredientsBigDivision: View {
 // MARK: Division View
 extension IngredientsBigDivision {
     private func 검색화면() -> some View {
-        VStack(spacing: 0) {
+        var filteredIngredients: [Ingredient] {
+            let ingredients = ingredientData.values.filter { ingredient in
+                (viewType == .new && ingredientUseCount[ingredient.id, default: 0] == 0) ||
+                (viewType == .old && ingredientUseCount[ingredient.id, default: 0] != 0)
+            }
+            return filterAndSortIngredients(by: searchText, from: ingredients)
+        }
+
+        
+        return VStack(spacing: 0) {
             TextFieldComponents().shortTextfield(placeHolder: "", value: $searchText, isFocused: $isSearchFieldFocused)
+                .overlay { RoundedRectangle(cornerRadius: 12).stroke(Color.buttonStrokeColor, lineWidth: 1) }
+            
+            VStack(alignment: .leading, spacing: 0) {
+                Spacer().frame(height: titleTopSpace)
+                Text(divisionCase.rawValue)
+                    .headerFont2()
+                    .foregroundColor(.defaultText)
+                Spacer().frame(height: titleBottomSpace)
+                ForEach(filteredIngredients, id: \.self) { ingredient in
+                    ingredientSelectRow(case: divisionCase, ingredient: ingredient, selected: $selectedIngredients, viewType: viewType)
+                        .padding(.vertical, 15)
+                }
+            }
         }
     }
     

--- a/Solidner/Views/Planning/AddPlan/AddIngredientBigDivision.swift
+++ b/Solidner/Views/Planning/AddPlan/AddIngredientBigDivision.swift
@@ -98,29 +98,29 @@ extension IngredientsBigDivision {
             
             ForEach(IngredientType.allCases, id: \.self) { type in
                 HStack(spacing: 0) {
-                    Button {
-                        withAnimation(.spring()) {
-                            toggleFoldState(foldStateList: &foldStates, type: type)
-                        }
-                    } label: {
-                        Text(type.description)
-                            .font(.system(size: 19, weight: .semibold))
-                            .padding(.trailing, 2)
-                        if divisionCase == .권장하지않는재료 {
-                            Image(systemName: "xmark.shield.fill")
-                                .foregroundStyle(Color.ageColor)
-                                .scaledToFit()
-                                .frame(width: 23)
-                        }
-                        Spacer()
-                        Image(systemName: foldStates[type]! ? "chevron.up" : "chevron.down")
-                            .resizable()
-                            .bold()
-                            .frame(width: 18, height: 10)
-                    }.foregroundColor(.black)
-                        .toggleStyle(.automatic)
-                }.buttonStyle(PlainButtonStyle())   // 깜빡임 제거
-                .padding(.vertical, foldSectionTitleVerticalPadding)
+                    Text(type.description)
+                        .font(.system(size: 19, weight: .semibold))
+                        .padding(.trailing, 2)
+                    if divisionCase == .권장하지않는재료 {
+                        Image(systemName: "xmark.shield.fill")
+                            .foregroundStyle(Color.ageColor)
+                            .scaledToFit()
+                            .frame(width: 23)
+                    }
+                    Spacer()
+                    Image(systemName: foldStates[type]! ? "chevron.up" : "chevron.down")
+                        .resizable()
+                        .bold()
+                        .frame(width: 18, height: 10)
+                }.padding(.vertical, foldSectionTitleVerticalPadding)
+                .contentShape(Rectangle())
+                .foregroundColor(.black)
+                .toggleStyle(.automatic)
+                .onTapGesture {
+                    withAnimation(.spring()) {
+                        toggleFoldState(foldStateList: &foldStates, type: type)
+                    }
+                }
                 
                 if foldStates[type]! {
                     Divider()

--- a/Solidner/Views/Planning/AddPlan/AddIngredientBigDivision.swift
+++ b/Solidner/Views/Planning/AddPlan/AddIngredientBigDivision.swift
@@ -79,6 +79,9 @@ struct IngredientsBigDivision: View {
     }
     
     private func filterAndSortIngredients(by searchTerm: String, from values: [Ingredient]) -> [Ingredient] {
+        if searchTerm.isEmpty {
+            return values.sorted { $0.name < $1.name }
+        }
         // 재료 name으로 filtering 및 sorting
         return values.filter { $0.name.localizedCaseInsensitiveContains(searchTerm) }
                      .sorted { $0.name < $1.name }
@@ -113,21 +116,15 @@ extension IngredientsBigDivision {
             return filterAndSortIngredients(by: searchText, from: ingredients)
         }
 
-        
         return VStack(spacing: 0) {
             TextFieldComponents().shortTextfield(placeHolder: "", value: $searchText, isFocused: $isSearchFieldFocused)
                 .overlay { RoundedRectangle(cornerRadius: 12).stroke(Color.buttonStrokeColor, lineWidth: 1) }
             
-            VStack(alignment: .leading, spacing: 0) {
-                Spacer().frame(height: titleTopSpace)
-                Text(divisionCase.rawValue)
-                    .headerFont2()
-                    .foregroundColor(.defaultText)
-                Spacer().frame(height: titleBottomSpace)
+                Divider()
+                    .padding(.top, foldSectionLightDividerBottomSpace)
                 ForEach(filteredIngredients, id: \.self) { ingredient in
                     ingredientSelectRow(case: divisionCase, ingredient: ingredient, selected: $selectedIngredients, viewType: viewType)
                         .padding(.vertical, 15)
-                }
             }
         }
     }

--- a/Solidner/Views/Planning/AddPlan/AddIngredientBigDivision.swift
+++ b/Solidner/Views/Planning/AddPlan/AddIngredientBigDivision.swift
@@ -243,6 +243,7 @@ extension IngredientsBigDivision {
         let divisionCase: DivisionCase
         let ingredient: Ingredient
         
+        @EnvironmentObject var mealOB: MealOB
         @Binding var selectedIngredients: [Int]
         let viewType: MealOB.IngredientTestType
         
@@ -267,7 +268,19 @@ extension IngredientsBigDivision {
         }
 
         var isNotRecommended: Bool {
+            // 선택된 재료와 궁합이 맞지 않으면
             for id in selectedIngredients {
+                if let misIngredients = ingredientData[id]?.misMatches {
+                    for misIngredient in misIngredients {
+                        if ingredient.id == misIngredient.id {
+                            return true
+                        }
+                    }
+                }
+            }
+            // mealOB의 반대 재료 (.new 일때 사용한 재료 / .old일때 새 재료)와 궁합이 맞지 않으면
+            for idResource in (viewType == .new ? mealOB.oldIngredients : mealOB.newIngredients) {
+                let id = idResource.id
                 if let misIngredients = ingredientData[id]?.misMatches {
                     for misIngredient in misIngredients {
                         if ingredient.id == misIngredient.id {
@@ -318,6 +331,7 @@ extension IngredientsBigDivision {
                 case .검색:
                     EmptyView()
                 }   // end of switch
+                
                 Spacer().frame(width: ingredientNameRightSpace)
                 if isNotRecommended {
                     Image(systemName: "exclamationmark.triangle.fill")
@@ -325,6 +339,7 @@ extension IngredientsBigDivision {
                         .scaledToFit()
                         .frame(width: 20)
                 }
+                
                 Spacer()
                 
                 ButtonComponents(.clickableTiny, disabledCondition: buttonDisableCondition, isClicked: isClicked) {

--- a/Solidner/Views/Planning/AddPlan/AddIngredientBigDivision.swift
+++ b/Solidner/Views/Planning/AddPlan/AddIngredientBigDivision.swift
@@ -12,6 +12,7 @@ enum DivisionCase: String {
     case 먹을수있는재료 = "먹을 수 있는 재료"
     case 권장하지않는재료 = "권장하지 않는 재료"
     case 자주사용한재료 = "자주 사용한 재료"
+    case 검색
 }
 
 struct IngredientsBigDivision: View {
@@ -51,10 +52,15 @@ struct IngredientsBigDivision: View {
     @Binding var ingredientUseCount: [Int: Int]
     @State private var foldStates: [IngredientType: Bool]
     
+    @State private var searchText = ""
+    @FocusState private var isSearchFieldFocused: Bool
+    
     let viewType: MealOB.IngredientTestType
     let initialSelectedIngredients: [Int]   // selectedIngredients 복사. 테스트 재료 추가 화면에서 정상적으로 보일 수 있게.
     
-    init(case divisionCase: DivisionCase, ingredients selectedIngredients: Binding<[Int]>, initSelected initialSelectedIngredients: [Int], viewType: MealOB.IngredientTestType, ingredientUseCount: Binding<[Int: Int]>) {
+    init(case divisionCase: DivisionCase, ingredients selectedIngredients: Binding<[Int]>,
+         initSelected initialSelectedIngredients: [Int], viewType: MealOB.IngredientTestType,
+         ingredientUseCount: Binding<[Int: Int]>) {
         self.divisionCase = divisionCase
         self.viewType = viewType
         self._ingredientUseCount = ingredientUseCount
@@ -83,6 +89,8 @@ struct IngredientsBigDivision: View {
                 먹을수있는권장하지않는Division()
             case .자주사용한재료:
                 자주사용한재료Division()
+            case .검색:
+                검색화면()
             }
         }.padding(.horizontal, viewHorizontalPadding)
     }
@@ -90,6 +98,12 @@ struct IngredientsBigDivision: View {
 
 // MARK: Division View
 extension IngredientsBigDivision {
+    private func 검색화면() -> some View {
+        VStack(spacing: 0) {
+            TextFieldComponents().shortTextfield(placeHolder: "", value: $searchText, isFocused: $isSearchFieldFocused)
+        }
+    }
+    
     private func 먹을수있는권장하지않는Division() -> some View {
         return VStack(alignment: .leading, spacing: 0) {
             Spacer().frame(height: titleTopSpace)
@@ -276,6 +290,8 @@ extension IngredientsBigDivision {
                                              VPad: dateTextVerticalPadding,
                                              color: .ageColor,
                                              radius: dateBackgroundRadius)
+                case .검색:
+                    EmptyView()
                 }   // end of switch
                 Spacer().frame(width: ingredientNameRightSpace)
                 if isNotRecommended {

--- a/Solidner/Views/Planning/AddPlan/AddTestIngredientsView.swift
+++ b/Solidner/Views/Planning/AddPlan/AddTestIngredientsView.swift
@@ -205,7 +205,9 @@ extension AddTestIngredientsView {
         let searchButtonStrokeLineWidth: CGFloat = 1
         
         return Button {
-            isSearching.toggle()
+            withAnimation {
+                isSearching.toggle()
+            }
         } label: {
             Image(systemName: "magnifyingglass")
                 .resizable()

--- a/Solidner/Views/Planning/AddPlan/AddTestIngredientsView.swift
+++ b/Solidner/Views/Planning/AddPlan/AddTestIngredientsView.swift
@@ -24,6 +24,7 @@ struct AddTestIngredientsView: View {
     private let reportButtonTopSpace: CGFloat = 20
     
     @State private var showReportSheet = false
+    @State private var isSearching = false
     
     @EnvironmentObject private var user: UserOB
     @EnvironmentObject private var mealOB: MealOB
@@ -51,40 +52,50 @@ struct AddTestIngredientsView: View {
             searchAndIngredientTypeButtonsRow
             
             // MARK: 선택된 재료 타입 확인 Row
-            selectedIngredientRow
+            if !isSearching {
+                selectedIngredientRow
+            }
             
             ScrollView {
-                if viewType == .new {
-                    // TODO: 추후 이상반응 기능 추가 시 활성화
-//                    IngredientsBigDivision(case: .이상반응재료,
-//                                           ingredients: $selectedIngredients,
-//                                           viewType: viewType)
-                } else {
-                    IngredientsBigDivision(case: .자주사용한재료,
+                if isSearching {
+                    IngredientsBigDivision(case: .검색,
                                            ingredients: $selectedIngredients,
                                            initSelected: initialSelectedIngredients,
                                            viewType: viewType,
                                            ingredientUseCount: $ingredientUseCount)
+                } else {
+                    if viewType == .new {
+                    // TODO: 추후 이상반응 기능 추가 시 활성화
+//                    IngredientsBigDivision(case: .이상반응재료,
+//                                           ingredients: $selectedIngredients,
+//                                           viewType: viewType)
+                    } else {
+                        IngredientsBigDivision(case: .자주사용한재료,
+                                               ingredients: $selectedIngredients,
+                                               initSelected: initialSelectedIngredients,
+                                               viewType: viewType,
+                                               ingredientUseCount: $ingredientUseCount)
+                    }
+                    
+                    ThickDivider().padding(.vertical, divisionDividerVerticalPadding)
+                    
+                    IngredientsBigDivision(case: .먹을수있는재료,
+                                           ingredients: $selectedIngredients,
+                                           initSelected: initialSelectedIngredients,
+                                           viewType: viewType,
+                                           ingredientUseCount: $ingredientUseCount)
+                    Spacer().frame(height: divisionDividerVerticalPadding)
+                    IngredientsBigDivision(case: .권장하지않는재료,
+                                           ingredients: $selectedIngredients,
+                                           initSelected: initialSelectedIngredients,
+                                           viewType: viewType,
+                                           ingredientUseCount: $ingredientUseCount)
+                    
+                    Spacer().frame(height: reportButtonTopSpace)
+                    reportButton
+                    
+                    Spacer().frame(height: saveButtonTopSpace)
                 }
-                
-                ThickDivider().padding(.vertical, divisionDividerVerticalPadding)
-                
-                IngredientsBigDivision(case: .먹을수있는재료,
-                                       ingredients: $selectedIngredients,
-                                       initSelected: initialSelectedIngredients,
-                                       viewType: viewType,
-                                       ingredientUseCount: $ingredientUseCount)
-                Spacer().frame(height: divisionDividerVerticalPadding)
-                IngredientsBigDivision(case: .권장하지않는재료,
-                                       ingredients: $selectedIngredients,
-                                       initSelected: initialSelectedIngredients,
-                                       viewType: viewType,
-                                       ingredientUseCount: $ingredientUseCount)
-                
-                Spacer().frame(height: reportButtonTopSpace)
-                reportButton
-                
-                Spacer().frame(height: saveButtonTopSpace)
             }
             Group {
                 Spacer().frame(height: saveButtonBottomSpace)
@@ -98,7 +109,6 @@ struct AddTestIngredientsView: View {
             .onAppear {
                 initSelectedIngredient()
                 countingIngredientUse()
-                print("appear")
             }
     }
 }
@@ -195,7 +205,7 @@ extension AddTestIngredientsView {
         let searchButtonStrokeLineWidth: CGFloat = 1
         
         return Button {
-            // TODO: Search
+            isSearching.toggle()
         } label: {
             Image(systemName: "magnifyingglass")
                 .resizable()

--- a/Solidner/Views/Planning/AddPlan/AddTestIngredientsView.swift
+++ b/Solidner/Views/Planning/AddPlan/AddTestIngredientsView.swift
@@ -35,6 +35,7 @@ struct AddTestIngredientsView: View {
     // 선택된 테스트 재료
     @State private var selectedIngredients: [Int] = []
     @State private var ingredientUseCount: [Int: Int] = [:]
+    @State private var initialSelectedIngredients: [Int] = []
     
     init(_ addIngredientViewType: MealOB.IngredientTestType) {
         self.viewType = addIngredientViewType
@@ -61,6 +62,7 @@ struct AddTestIngredientsView: View {
                 } else {
                     IngredientsBigDivision(case: .자주사용한재료,
                                            ingredients: $selectedIngredients,
+                                           initSelected: initialSelectedIngredients,
                                            viewType: viewType,
                                            ingredientUseCount: $ingredientUseCount)
                 }
@@ -69,11 +71,13 @@ struct AddTestIngredientsView: View {
                 
                 IngredientsBigDivision(case: .먹을수있는재료,
                                        ingredients: $selectedIngredients,
+                                       initSelected: initialSelectedIngredients,
                                        viewType: viewType,
                                        ingredientUseCount: $ingredientUseCount)
                 Spacer().frame(height: divisionDividerVerticalPadding)
                 IngredientsBigDivision(case: .권장하지않는재료,
                                        ingredients: $selectedIngredients,
+                                       initSelected: initialSelectedIngredients,
                                        viewType: viewType,
                                        ingredientUseCount: $ingredientUseCount)
                 
@@ -94,6 +98,7 @@ struct AddTestIngredientsView: View {
             .onAppear {
                 initSelectedIngredient()
                 countingIngredientUse()
+                print("appear")
             }
     }
 }
@@ -243,10 +248,12 @@ extension AddTestIngredientsView {
             for ingredient in mealOB.newIngredients {
                 selectedIngredients.append(ingredient.id)
             }
+            initialSelectedIngredients = selectedIngredients
         case .old:
             for ingredient in mealOB.oldIngredients {
                 selectedIngredients.append(ingredient.id)
             }
+            initialSelectedIngredients = selectedIngredients
         }
     }
     

--- a/Solidner/Views/Planning/AddPlan/AddTestIngredientsView.swift
+++ b/Solidner/Views/Planning/AddPlan/AddTestIngredientsView.swift
@@ -65,13 +65,13 @@ struct AddTestIngredientsView: View {
         self.viewType = addIngredientViewType
     }
     
+    @Namespace var 맨위
     @Namespace var 채소1
     @Namespace var 과일1
     @Namespace var 곡물1
     @Namespace var 어육류1
     @Namespace var 유제품1
     @Namespace var 기타1
-    
     @Namespace var 채소2
     @Namespace var 과일2
     @Namespace var 곡물2
@@ -117,7 +117,7 @@ struct AddTestIngredientsView: View {
                                                        initSelected: initialSelectedIngredients,
                                                        viewType: viewType,
                                                        ingredientUseCount: $ingredientUseCount,
-                                                       scrollID: scrollID)
+                                                       scrollID: scrollID).id(맨위)
                                 ThickDivider().padding(.vertical, divisionDividerVerticalPadding)
                             }
                             
@@ -126,7 +126,7 @@ struct AddTestIngredientsView: View {
                                                    initSelected: initialSelectedIngredients,
                                                    viewType: viewType,
                                                    ingredientUseCount: $ingredientUseCount,
-                                                   scrollID: scrollID)
+                                                   scrollID: scrollID).id(맨위)
                             Spacer().frame(height: divisionDividerVerticalPadding)
                             IngredientsBigDivision(case: .권장하지않는재료,
                                                    ingredients: $selectedIngredients,
@@ -184,7 +184,7 @@ extension AddTestIngredientsView {
     private func searchAndIngredientTypeButtonsRow(proxy: ScrollViewProxy) -> some View {
         return ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: typeButtonBetweenSpace) {
-                searchButton
+                searchButton(proxy: proxy)
                 ForEach(Array(IngredientType.allCases.enumerated()), id: \.element) { index, type in
                     ingredientTypeButton(proxy, type.description, namespace: index, recommend: true)
                 }
@@ -247,7 +247,7 @@ extension AddTestIngredientsView {
             HStack(spacing: 0) {
                 Text(text)
                     .bodyFont2()
-                    .foregroundColor(.defaultText)
+                    .foregroundColor(.defaultText.opacity(0.6))
                     .frame(height: buttonFrameHeight)
                 Spacer().frame(width: textAndMarkSpace)
                 if !recommend {
@@ -267,7 +267,7 @@ extension AddTestIngredientsView {
     }
     
     // MARK: 검색 버튼
-    private var searchButton: some View {
+    private func searchButton(proxy: ScrollViewProxy) -> some View {
         let searchIconSize: CGFloat = 20
         let buttonFrameWidth: CGFloat = 70
         let buttonFrameHeight: CGFloat = 40
@@ -276,6 +276,7 @@ extension AddTestIngredientsView {
         
         return Button {
             withAnimation {
+                proxy.scrollTo(맨위, anchor: .top)
                 isSearching.toggle()
             }
         } label: {
@@ -300,7 +301,6 @@ extension AddTestIngredientsView {
         let verticalPadding: CGFloat = 7
         let cornerRadius: CGFloat = 6
         
-        // TODO: 재료 타입에 따른 color가 되도록 수정
         return Text("\(ingredient.name)")
             .bodyFont3()
             .foregroundColor(.secondaryText)

--- a/Solidner/Views/Planning/AddPlan/AddTestIngredientsView.swift
+++ b/Solidner/Views/Planning/AddPlan/AddTestIngredientsView.swift
@@ -7,6 +7,29 @@
 
 import SwiftUI
 
+// 스크롤 id 저장.
+struct ScrollID {
+    var 채소1: Namespace.ID
+    var 과일1: Namespace.ID
+    var 곡물1: Namespace.ID
+    var 어육류1: Namespace.ID
+    var 유제품1: Namespace.ID
+    var 기타1: Namespace.ID
+    var 채소2: Namespace.ID
+    var 과일2: Namespace.ID
+    var 곡물2: Namespace.ID
+    var 어육류2: Namespace.ID
+    var 유제품2: Namespace.ID
+    var 기타2: Namespace.ID
+    
+    var namespaces1: [Namespace.ID] {
+        return [채소1, 과일1, 곡물1, 어육류1, 유제품1, 기타1]
+    }
+    var namespaces2: [Namespace.ID] {
+        return [채소2, 과일2, 곡물2, 어육류2, 유제품2, 기타2]
+    }
+}
+
 struct AddTestIngredientsView: View {
     // TODO: 전체적인 Padding 계층 및 Magic Number 수정 요함
     private let ingredientData = IngredientData.shared.ingredients
@@ -42,59 +65,82 @@ struct AddTestIngredientsView: View {
         self.viewType = addIngredientViewType
     }
     
+    @Namespace var 채소1
+    @Namespace var 과일1
+    @Namespace var 곡물1
+    @Namespace var 어육류1
+    @Namespace var 유제품1
+    @Namespace var 기타1
+    
+    @Namespace var 채소2
+    @Namespace var 과일2
+    @Namespace var 곡물2
+    @Namespace var 어육류2
+    @Namespace var 유제품2
+    @Namespace var 기타2
+    @State var scrollID: ScrollID?
+    
+    @State private var selectedIngredientType: (Int, Bool) = (0, false)
     
     // MARK: body
     var body: some View {
         VStack(spacing: 0) {
             BackButtonAndTitleHeader(title: Texts.testViewTitle(viewType: viewType))
             
-            // MARK: 검색, 재료 타입 버튼
-            searchAndIngredientTypeButtonsRow
-            
-            // MARK: 선택된 재료 타입 확인 Row
-            if !isSearching {
-                selectedIngredientRow
-            }
-            
-            ScrollView {
-                if isSearching {
-                    IngredientsBigDivision(case: .검색,
-                                           ingredients: $selectedIngredients,
-                                           initSelected: initialSelectedIngredients,
-                                           viewType: viewType,
-                                           ingredientUseCount: $ingredientUseCount)
-                } else {
-                    if viewType == .new {
-                    // TODO: 추후 이상반응 기능 추가 시 활성화
-//                    IngredientsBigDivision(case: .이상반응재료,
-//                                           ingredients: $selectedIngredients,
-//                                           viewType: viewType)
-                    } else {
-                        IngredientsBigDivision(case: .자주사용한재료,
-                                               ingredients: $selectedIngredients,
-                                               initSelected: initialSelectedIngredients,
-                                               viewType: viewType,
-                                               ingredientUseCount: $ingredientUseCount)
+            ScrollViewReader { proxy in
+                // MARK: 검색, 재료 타입 버튼
+                searchAndIngredientTypeButtonsRow(proxy: proxy)
+                
+                // MARK: 선택된 재료 타입 확인 Row
+                if !isSearching {
+                    selectedIngredientRow
+                }
+                
+                ScrollView {
+                    if let scrollID = scrollID {
+                        if isSearching {
+                            IngredientsBigDivision(case: .검색,
+                                                   ingredients: $selectedIngredients,
+                                                   initSelected: initialSelectedIngredients,
+                                                   viewType: viewType,
+                                                   ingredientUseCount: $ingredientUseCount,
+                                                   scrollID: scrollID)
+                        } else {
+                            if viewType == .new {
+                                // TODO: 추후 이상반응 기능 추가 시 활성화
+                                //                    IngredientsBigDivision(case: .이상반응재료,
+                                //                                           ingredients: $selectedIngredients,
+                                //                                           viewType: viewType)
+                            } else {
+                                IngredientsBigDivision(case: .자주사용한재료,
+                                                       ingredients: $selectedIngredients,
+                                                       initSelected: initialSelectedIngredients,
+                                                       viewType: viewType,
+                                                       ingredientUseCount: $ingredientUseCount,
+                                                       scrollID: scrollID)
+                                ThickDivider().padding(.vertical, divisionDividerVerticalPadding)
+                            }
+                            
+                            IngredientsBigDivision(case: .먹을수있는재료,
+                                                   ingredients: $selectedIngredients,
+                                                   initSelected: initialSelectedIngredients,
+                                                   viewType: viewType,
+                                                   ingredientUseCount: $ingredientUseCount,
+                                                   scrollID: scrollID)
+                            Spacer().frame(height: divisionDividerVerticalPadding)
+                            IngredientsBigDivision(case: .권장하지않는재료,
+                                                   ingredients: $selectedIngredients,
+                                                   initSelected: initialSelectedIngredients,
+                                                   viewType: viewType,
+                                                   ingredientUseCount: $ingredientUseCount,
+                                                   scrollID: scrollID)
+                            
+                            Spacer().frame(height: reportButtonTopSpace)
+                            reportButton
+                            
+                            Spacer().frame(height: saveButtonTopSpace)
+                        }
                     }
-                    
-                    ThickDivider().padding(.vertical, divisionDividerVerticalPadding)
-                    
-                    IngredientsBigDivision(case: .먹을수있는재료,
-                                           ingredients: $selectedIngredients,
-                                           initSelected: initialSelectedIngredients,
-                                           viewType: viewType,
-                                           ingredientUseCount: $ingredientUseCount)
-                    Spacer().frame(height: divisionDividerVerticalPadding)
-                    IngredientsBigDivision(case: .권장하지않는재료,
-                                           ingredients: $selectedIngredients,
-                                           initSelected: initialSelectedIngredients,
-                                           viewType: viewType,
-                                           ingredientUseCount: $ingredientUseCount)
-                    
-                    Spacer().frame(height: reportButtonTopSpace)
-                    reportButton
-                    
-                    Spacer().frame(height: saveButtonTopSpace)
                 }
             }
             Group {
@@ -109,6 +155,9 @@ struct AddTestIngredientsView: View {
             .onAppear {
                 initSelectedIngredient()
                 countingIngredientUse()
+            }.task {
+                scrollID = ScrollID(채소1: 채소1, 과일1: 과일1, 곡물1: 곡물1, 어육류1: 어육류1, 유제품1: 유제품1, 기타1: 기타1,
+                                    채소2: 채소2, 과일2: 과일2, 곡물2: 곡물2, 어육류2: 어육류2, 유제품2: 유제품2, 기타2: 기타2)
             }
     }
 }
@@ -132,14 +181,17 @@ extension AddTestIngredientsView {
 //        )
 //    }
     
-    private var searchAndIngredientTypeButtonsRow: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
+    private func searchAndIngredientTypeButtonsRow(proxy: ScrollViewProxy) -> some View {
+        return ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: typeButtonBetweenSpace) {
                 searchButton
-                ForEach(TempIngredientType.allCases, id: \.self) { ingredientType in
-                    ingredientTypeButton(ingredientType.rawValue)
+                ForEach(Array(IngredientType.allCases.enumerated()), id: \.element) { index, type in
+                    ingredientTypeButton(proxy, type.description, namespace: index, recommend: true)
                 }
-            }.padding(.leading, viewHorizontalPadding)
+                ForEach(Array(IngredientType.allCases.enumerated()), id: \.element) { index, type in
+                    ingredientTypeButton(proxy, type.description, namespace: index, recommend: false)
+                }
+            }.padding(.horizontal, viewHorizontalPadding)
         }.padding(.bottom, typeButtonsRowBottomPadding)
     }
     
@@ -175,24 +227,42 @@ extension AddTestIngredientsView {
     }
     
     // MARK: 테스트 재료 분류
-    private func ingredientTypeButton(_ text: String) -> some View {
+    private func ingredientTypeButton(_ proxy: ScrollViewProxy, _ text: String, namespace index: Int, recommend: Bool) -> some View {
         let textHorizontalPadding: CGFloat = 17
         let buttonFrameHeight: CGFloat = 40
         let buttonBackgroundRadius: CGFloat = 27.5
+        let textAndMarkSpace: CGFloat = 4
+        let buttonTrailingPadding: CGFloat = 13
         
         return Button {
             // TODO: 재료 분류에 따라 리스트 추가, 버튼 기능, 스크롤 따라가기, 선택여부따라 색 변경
-        } label: {
-            Text(text)
-                .bodyFont2()
-                .foregroundColor(.defaultText_wh)
-                .padding(.horizontal, textHorizontalPadding)
-                .frame(height: buttonFrameHeight)
-                .background {
-                    RoundedRectangle(cornerRadius: buttonBackgroundRadius)
-                        .fill(Color.secondaryText)
-                    //                        .fill(Color.defaultText_wh)
+            withAnimation {
+                if recommend {
+                    proxy.scrollTo(scrollID?.namespaces1[index], anchor: .top)
+                } else {
+                    proxy.scrollTo(scrollID?.namespaces2[index], anchor: .top)
                 }
+            }
+        } label: {
+            HStack(spacing: 0) {
+                Text(text)
+                    .bodyFont2()
+                    .foregroundColor(.defaultText)
+                    .frame(height: buttonFrameHeight)
+                Spacer().frame(width: textAndMarkSpace)
+                if !recommend {
+                    Image(systemName: "xmark.shield.fill")
+                        .foregroundStyle(Color.ageColor)
+                        .scaledToFit()
+                        .frame(width: 20)
+                }
+            }.padding(.leading, textHorizontalPadding)
+            .padding(.trailing, buttonTrailingPadding)
+            .background {
+                RoundedRectangle(cornerRadius: buttonBackgroundRadius)
+//                    .fill(Color.secondaryText)
+                        .fill(Color.defaultText_wh)
+            }
         }
     }
     
@@ -279,18 +349,5 @@ extension AddTestIngredientsView {
                 ingredientUseCount[ingredient.id, default: 0] += 1
             }
         }
-    }
-}
-
-extension AddTestIngredientsView {
-    // MARK: IngredientType
-    enum TempIngredientType: String, CaseIterable {
-        case 이상반응재료 = "이상 반응 재료"
-        case 곡류 = "곡류"
-        case 채소류 = "채소류"
-        case 과일류 = "과일류"
-        case 육어류 = "육류&어류"
-        case 유제품류 = "유제품류"
-        case 기타 = "기타"
     }
 }

--- a/Solidner/Views/Planning/Monthly/MonthlyPlanningView.swift
+++ b/Solidner/Views/Planning/Monthly/MonthlyPlanningView.swift
@@ -380,7 +380,7 @@ struct MonthlyPlanningView: View {
                         if mealPlans.count != .zero {
                             DailyPlanListView(date: date, mealPlans: mealPlans)
                         } else {
-                            MealDetailView(startDate: date, cycleGap: user.planCycleGap)
+                            MealDetailView(startDate: date, cycleGap: user.planCycleGap, mealPlansOB: mealPlansOB)
                         }
                     } label: {
                         VStack(spacing: 0) {


### PR DESCRIPTION
## What I Did!
<!-- 작업 내용과 참고 스크린샷 첨부 -->

* [x] 검색 기능 구현
* [x] 하단 버튼 fixed 처리 및 토스트메시지 구현
* [x] 새로운 재료 / 사용한 적 없는 재료에 따라 리스트에 뜨는 재료가 다르도록 변경
  * [x] 뷰 appear 시 재료 사용 횟수 카운팅 (임시)
  * [x] 자주 사용한 재료 구분
>   * [ ] IngredientUseCount 함수 작성
>   * [ ] save / delete 시 IngredientUseCount 업데이트

* [x] 검색 버튼 옆 재료 구분 버튼 -> 스크롤 수정
* [x] 재료 리포트 기능 구현


## Issue

<!-- 참고할 Issue와 연관된 Issue를 적어주세요. (ex. #1, close #2) -->

close #88 


## Review Point
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->

- struct를 통해 namespace.id를 저장하고, 이를 하위 view로 전달하여, 스크롤의 각 위치에 id를 달아 상위 뷰에서 강제 scroll
https://github.com/DeveloperAcademy-POSTECH/MacC-Team15-GearCo/blob/80fa31b499f203df5feab0b1b62c5fd3745c8048/Solidner/Views/Planning/AddPlan/AddTestIngredientsView.swift#L11-L31

- 검색 기능 구현
https://github.com/DeveloperAcademy-POSTECH/MacC-Team15-GearCo/blob/80fa31b499f203df5feab0b1b62c5fd3745c8048/Solidner/Views/Planning/AddPlan/AddIngredientBigDivision.swift#L84-L91

- 그리고 각종 디자인, 애니메이션적 수정 여러 가지