### PR TITLE
Fix: 네비게이션 이슈 해결 완료

### DIFF
--- a/Solidner.xcodeproj/project.pbxproj
+++ b/Solidner.xcodeproj/project.pbxproj
@@ -954,7 +954,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Solidner/Preview Content\"";
-				DEVELOPMENT_TEAM = PAQ92DM7XD;
+				DEVELOPMENT_TEAM = G8XX337GMH;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Solidner/Info.plist;
@@ -969,7 +969,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.jeckmu.Solidner;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swimmer.Solidner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -991,7 +991,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Solidner/Preview Content\"";
-				DEVELOPMENT_TEAM = PAQ92DM7XD;
+				DEVELOPMENT_TEAM = G8XX337GMH;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Solidner/Info.plist;
@@ -1006,7 +1006,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.jeckmu.Solidner;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swimmer.Solidner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Solidner/Views/Mypage/UserInfoUpdateView.swift
+++ b/Solidner/Views/Mypage/UserInfoUpdateView.swift
@@ -23,7 +23,7 @@ struct UserInfoUpdateView: View {
     @FocusState private var isNicknameFocused: Bool
     @FocusState private var isBabynameFocused: Bool
     @EnvironmentObject var user: UserOB
-    @Environment(\.presentationMode) private var presentationMode: Binding<PresentationMode>
+    @Environment(\.dismiss) private var dismiss
     var body: some View {
         GeometryReader { _ in
             ZStack {
@@ -116,7 +116,7 @@ struct UserInfoUpdateView: View {
                 user.babyBirthDate = updatedBabyBirthDate
                 user.solidStartDate = updatedSolidStartDate
                 //🔴 서버 유저정보 업데이트 코드 추가
-                presentationMode.wrappedValue.dismiss()
+                dismiss()
             }
             .padding(.top, 40)
         }

--- a/Solidner/Views/Onboarding/BabyBirthDateView.swift
+++ b/Solidner/Views/Onboarding/BabyBirthDateView.swift
@@ -14,7 +14,7 @@ struct BabyBirthDateView: View {
     @State private var babyBirthDate = Date()
     @State private var navigationIsPresented = false
     @Binding var tempUserInfo: TempUserInfo
-//    @EnvironmentObject var user: UserOB
+    @EnvironmentObject var user: UserOB
     var body: some View {
         ZStack {
             BackgroundView()
@@ -45,6 +45,7 @@ struct BabyBirthDateView: View {
             Spacer()
             ButtonComponents(.big, disabledCondition: false, action: {
                 tempUserInfo.babyBirthDate = babyBirthDate
+                user.babyBirthDate = babyBirthDate
                 navigationIsPresented = true
             })
         }

--- a/Solidner/Views/Onboarding/FoodStartDateView.swift
+++ b/Solidner/Views/Onboarding/FoodStartDateView.swift
@@ -11,7 +11,7 @@ struct FoodStartDateView: View {
     private let datePickerTopPadding = 64.0
     @State private var solidStartDate = Date()
     @State private var navigationIsPresented = false
-//    @EnvironmentObject var user: UserOB
+    @EnvironmentObject var user: UserOB
     @Binding var tempUserInfo: TempUserInfo
     var body: some View {
         ZStack {
@@ -33,6 +33,7 @@ struct FoodStartDateView: View {
             Spacer()
             ButtonComponents(.big, disabledCondition: false) {
                 tempUserInfo.solidStartDate = solidStartDate
+                user.solidStartDate = solidStartDate
                 navigationIsPresented = true
             }
         }

--- a/Solidner/Views/Onboarding/NickNameView.swift
+++ b/Solidner/Views/Onboarding/NickNameView.swift
@@ -15,7 +15,7 @@ struct NickNameView: View {
     let nickNameViewCase: NickNameViewCase
     @StateObject private var keyboardHeightHelper = KeyboardHeightHelperOB()
     @FocusState private var isFocused: Bool
-//    @EnvironmentObject var user: UserOB
+    @EnvironmentObject var user: UserOB
     @Binding var tempUserInfo: TempUserInfo
     @State private var babyNameViewIsPresented = false
     @State private var navigationIsPresented = false
@@ -45,9 +45,11 @@ struct NickNameView: View {
                     ButtonComponents().smallButton(disabledCondition: inputText.isEmpty) {
                         switch nickNameViewCase {
                         case .userName :
+                            user.nickName = inputText
                             tempUserInfo.nickName = inputText
                             babyNameViewIsPresented = true
                         case .babyName :
+                            user.nickName = inputText
                             tempUserInfo.babyName = inputText
                             navigationIsPresented = true
                         }


### PR DESCRIPTION
## What I Did!
현재 dev에서 다음과 같은 이슈가 발생합니다.
- 앱을 키면 다시 닉네임 입력 뷰로 인입 되는 문제
- 마이페이지에서 수정 완료를 눌렀을때 이용약관 뷰로 인입되는 문제

이 문제의 원인은 현재 유저 정보가 기존의 UserOB에서 저장되는게 아니라 TempUserInfo에서 저장되는데 반해,
App파일에서 네비게이션은 UserOB 정보의 isEmpty를 기준으로 분기처리 되고 있기 때문입니다.
따라서 기존 정보를 받는 뷰에서 커멘팅 되어있던 user 변수를 다시 코드에 추가하고, TempUserInfo와 함께 UserOB 정보도 받는 방식으로 변경했습니다. 

그랬더니 해결 완료~



## Issue


close #108 



## Review Point
<img width="802" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team15-GearCo/assets/69354045/5a92afc3-abfd-4aa1-bbf0-0427d48dc9b1">




