### PR TITLE
[Feat/#113] 일부 화면 SE 기기대응, 회원정보 관련 기능 추가, 디자인 수정 등

### DIFF
--- a/Solidner.xcodeproj/project.pbxproj
+++ b/Solidner.xcodeproj/project.pbxproj
@@ -327,13 +327,6 @@
 			path = Weekly;
 			sourceTree = "<group>";
 		};
-		B208B1312B1CEF3C00968A87 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
 		B219F11D2B0C90FE00886087 /* StartPlan */ = {
 			isa = PBXGroup;
 			children = (
@@ -443,7 +436,6 @@
 		C3C6375B2AF90C2B006D464D /* Solidner */ = {
 			isa = PBXGroup;
 			children = (
-				B208B1312B1CEF3C00968A87 /* Resources */,
 				C336EE4F2B054A300057D8B8 /* Info.plist */,
 				0E613A252B131B9B00AF75BF /* IngredientData.json */,
 				0E18AD682AFA7A260011ED4A /* Solidner.entitlements */,
@@ -970,7 +962,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Solidner/Preview Content\"";
-				DEVELOPMENT_TEAM = 6BHXWP5PYW;
+				DEVELOPMENT_TEAM = PAQ92DM7XD;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Solidner/Info.plist;
@@ -985,7 +977,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.ollie.Solidner;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jeckmu.Solidner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1007,7 +999,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Solidner/Preview Content\"";
-				DEVELOPMENT_TEAM = 6BHXWP5PYW;
+				DEVELOPMENT_TEAM = PAQ92DM7XD;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Solidner/Info.plist;
@@ -1022,7 +1014,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.ollie.Solidner;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jeckmu.Solidner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Solidner/Network/FirebaseManager.swift
+++ b/Solidner/Network/FirebaseManager.swift
@@ -67,6 +67,26 @@ extension FirebaseManager {
             throw error
         }
     }
+    
+    func updateUser(_ email: String, nickName: String, babyName: String, babyBirth: Date, solidStart: Date) async throws {
+        let colRef = getColRef(.User)
+        let docRef = colRef.getDocRef(email)
+        
+        let dataToUpdate: [String: Any] = [
+            "nickName": nickName,
+            "babyName": babyName,
+            "babyBirthDate": Timestamp(date: babyBirth),
+            "solidStartDate": Timestamp(date: solidStart)
+        ]
+        
+        do {
+            try await docRef.setData(dataToUpdate, merge: true)
+            print("회원 정보를 수정했습니다. - id: \(email)")
+        } catch {
+            print("회원 정보 수정에 실패했습니다.")
+            throw error
+        }
+    }
 }
 
 // MARK: 없는 재료 리포트

--- a/Solidner/Views/Mypage/MypageRootView.swift
+++ b/Solidner/Views/Mypage/MypageRootView.swift
@@ -15,10 +15,12 @@ struct MypageRootView: View {
     var body: some View {
         ZStack {
             BackgroundView()
-            VStack(spacing: 0) {
-                BackButtonAndTitleHeader(title: "프로필")
-                viewBody()
-                    .padding(horizontal: 20, top: 22.8, bottom: 0)
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 0) {
+                    BackButtonAndTitleHeader(title: "프로필")
+                    viewBody()
+                        .padding(horizontal: 20, top: 22.8, bottom: 0)
+                }
             }
         }
         .alert(isPresented: $showLogoutAlert) {
@@ -166,6 +168,7 @@ struct MypageRootView: View {
             logoutButton()
                 .padding(.top, -4)
             myPageFunctionButton(mypageFuctionCase: .withdrawal)
+            Spacer().frame(height: 30)
         }
     }
 }

--- a/Solidner/Views/Mypage/UserInfoUpdateView.swift
+++ b/Solidner/Views/Mypage/UserInfoUpdateView.swift
@@ -32,15 +32,17 @@ struct UserInfoUpdateView: View {
         GeometryReader { _ in
             ZStack {
                 BackgroundView()
-                VStack(spacing: 0) {
-                    BackButtonAndTitleHeader(title: "회원정보 수정")
-                    viewBody()
-                        .padding(horizontal: 20, top: 26.88, bottom: 6)
-                }.task {
-                    nickNameInputText = user.nickName
-                    babyNameInputText = user.babyName
-                    updatedBabyBirthDate = user.babyBirthDate
-                    updatedSolidStartDate = user.solidStartDate
+                ScrollView(showsIndicators: false) {
+                    VStack(spacing: 0) {
+                        BackButtonAndTitleHeader(title: "회원정보 수정")
+                        viewBody()
+                            .padding(horizontal: 20, top: 26.88, bottom: 6)
+                    }.task {
+                        nickNameInputText = user.nickName
+                        babyNameInputText = user.babyName
+                        updatedBabyBirthDate = user.babyBirthDate
+                        updatedSolidStartDate = user.solidStartDate
+                    }
                 }
             }
             .sheet(isPresented: $showBabyBirthDateModal, content: {
@@ -99,10 +101,10 @@ struct UserInfoUpdateView: View {
         var disableCondition: Bool {
             nickNameInputText.isEmpty || nickNameInputText.count > limit || babyNameInputText.isEmpty || babyNameInputText.count > limit
         }
-                
+        
         return VStack(spacing: 0) {
             userInfoUpdateList()
-            Spacer()
+            Spacer().frame(height: 35)
             VStack {
                 Button(action: {
                     showAddMoreUserFYIModal = true
@@ -110,13 +112,14 @@ struct UserInfoUpdateView: View {
                     VStack(spacing: 3) {
                         Text("양육자, 아이 추가를 찾으시나요?")
                             .clickableTextFont2()
-                        .foregroundColor(.tertinaryText)
+                            .foregroundColor(.tertinaryText)
                         Rectangle()
                             .fill(Color.tertinaryText)
                             .frame(width: 166, height: 1)
                     }
                 }
             }
+            Spacer().frame(height: 40)
             ButtonComponents(.big, title: "수정 완료", disabledCondition: disableCondition) {
                 Task {
                     do {
@@ -131,7 +134,7 @@ struct UserInfoUpdateView: View {
                         self.err = error
                     }
                 }
-            }.padding(.top, 40)
+            }.padding(.bottom, 25)
         }.alert("에러 발생", isPresented: $showFailureAlert, presenting: err) { err in
             Button("확인") { showFailureAlert = false }
         } message: { error in
@@ -152,7 +155,7 @@ struct UserInfoUpdateView: View {
         VStack(alignment: .leading, spacing: 16) {
             Text(userInfoCase.rawValue)
                 .headerFont4()
-            .foregroundColor(.defaultText.opacity(0.8))
+                .foregroundColor(.defaultText.opacity(0.8))
             switch userInfoCase {
             case .nickName:
                 nickNameTextField()

--- a/Solidner/Views/Mypage/UserInfoUpdateView.swift
+++ b/Solidner/Views/Mypage/UserInfoUpdateView.swift
@@ -32,6 +32,11 @@ struct UserInfoUpdateView: View {
                     BackButtonAndTitleHeader(title: "회원정보 수정")
                     viewBody()
                         .padding(horizontal: 20, top: 26.88, bottom: 6)
+                }.task {
+                    nickNameInputText = user.nickName
+                    babyNameInputText = user.babyName
+                    updatedBabyBirthDate = user.babyBirthDate
+                    updatedSolidStartDate = user.solidStartDate
                 }
             }
             .sheet(isPresented: $showBabyBirthDateModal, content: {
@@ -82,18 +87,16 @@ struct UserInfoUpdateView: View {
                 isNicknameFocused = false
             }
         }
-        .onAppear {
-            nickNameInputText = user.nickName
-            babyNameInputText = user.babyName
-            updatedBabyBirthDate = user.babyBirthDate
-            updatedSolidStartDate = user.solidStartDate
-        }
         .ignoresSafeArea(.keyboard, edges: .bottom)
         .navigationBarBackButtonHidden(true)
         .navigationBarHidden(true)
     }
     private func viewBody() -> some View {
-        VStack(spacing: 0) {
+        var disableCondition: Bool {
+            nickNameInputText.isEmpty || nickNameInputText.count > limit || babyNameInputText.isEmpty || babyNameInputText.count > limit
+        }
+        
+        return VStack(spacing: 0) {
             userInfoUpdateList()
             Spacer()
             VStack {
@@ -110,7 +113,7 @@ struct UserInfoUpdateView: View {
                     }
                 }
             }
-            ButtonComponents(.big, title: "수정 완료", disabledCondition: false) {
+            ButtonComponents(.big, title: "수정 완료", disabledCondition: disableCondition) {
                 user.babyName = babyNameInputText
                 user.nickName = nickNameInputText
                 user.babyBirthDate = updatedBabyBirthDate
@@ -152,7 +155,7 @@ struct UserInfoUpdateView: View {
                 .onReceive(nickNameInputText.publisher.collect()) { collectionText in
                     let trimmedText = String(collectionText.prefix(limit))
                     if nickNameInputText != trimmedText {
-                        nickNameHasReachedLimit = nickNameInputText.count > limit ? true : false
+                        nickNameHasReachedLimit = (nickNameInputText.count > limit || nickNameInputText.isEmpty) ? true : false
                         nickNameInputText = trimmedText
                     }
                 }
@@ -172,7 +175,7 @@ struct UserInfoUpdateView: View {
                 .onReceive(babyNameInputText.publisher.collect()) { collectionText in
                     let trimmedText = String(collectionText.prefix(limit))
                     if babyNameInputText != trimmedText {
-                        babyNameHasReachedLimit = babyNameInputText.count > limit ? true : false
+                        babyNameHasReachedLimit = (babyNameInputText.count > limit || babyNameInputText.isEmpty) ? true : false
                         babyNameInputText = trimmedText
                     }
                 }

--- a/Solidner/Views/Planning/Monthly/MonthlyPlanningView.swift
+++ b/Solidner/Views/Planning/Monthly/MonthlyPlanningView.swift
@@ -63,7 +63,7 @@ struct MonthlyPlanningView: View {
 //            }
 
             monthlyHeader
-//                .padding(.bottom, 16)
+            
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 0) {
                     calendarCurrentYearMonth.padding(.bottom, 26)
@@ -78,11 +78,12 @@ struct MonthlyPlanningView: View {
                         RoundedRectangle(cornerRadius: 12)
                             .foregroundColor(.defaultText_wh)
                     }
-                    Spacer().frame(height: 200)
+                    Spacer().frame(height: 100.responsibleHeight)
                     ThickDivider()
                         .padding(.horizontal, -16)
+                    // TODO: Magic Number 수정
                     totalSetting
-                        .padding(top: 26, leading: 0, bottom: 100, trailing: 0)
+                        .padding(top: 26.responsibleHeight, leading: 0, bottom: 75.responsibleHeight, trailing: 0)
                 }.padding(.horizontal, 16).clipped()
                     .defaultViewBodyTopPadding()
             }
@@ -628,9 +629,3 @@ extension MonthlyPlanningView {
         return result.sorted { $0.0.startDay < $1.0.startDay }    // startDate 순 정렬
     }
 }
-
-//struct MonthlyPlanningView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        MonthlyPlanningView()
-//    }
-//}

--- a/Solidner/Views/Planning/StartPlan/StartPlanView.swift
+++ b/Solidner/Views/Planning/StartPlan/StartPlanView.swift
@@ -124,7 +124,7 @@ extension StartPlanView {
         static var goToPlanButtonLabelframeHeight: CGFloat { 60.responsibleHeight }
         static var goToPlanButtonLabelBackgroundCornerRadius: CGFloat { 50 }
         static var goToPlanButtonLabelBackgroundColor: Color { .accentColor1 }
-        static var modalHeight: CGFloat { 498.responsibleHeight }
+        static var modalHeight: CGFloat { 498 }
         static var modalPresentationCornerRadius: CGFloat { 25 }
         static var buttonBottomSpace: CGFloat { 35.responsibleHeight }
     }

--- a/Solidner/Views/Planning/StartPlan/StartPlanView.swift
+++ b/Solidner/Views/Planning/StartPlan/StartPlanView.swift
@@ -37,7 +37,7 @@ struct StartPlanView: View {
             ingredientsImage
             titleAndHint
             goToPlanButton
-            Spacer()
+            Spacer().frame(height: K.buttonBottomSpace)
         }
         .navigationDestination(isPresented: $isMyPageOpenning) {
             MypageRootView()
@@ -64,6 +64,8 @@ struct StartPlanView: View {
     
     private var ingredientsImage: some View {
         Image(assetName: .ingredientsInStart)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
             .padding(.bottom, K.ingredientsImagePaddingBottom)
     }
 
@@ -115,15 +117,16 @@ struct StartPlanView: View {
 
 extension StartPlanView {
     private enum K {
-        static var topSpacerHeight: CGFloat { 20 }
-        static var ingredientsImagePaddingBottom: CGFloat { 45 }
-        static var titleAndHintPaddingBottom: CGFloat { 30 }
-        static var goToPlanButtonLabelPaddingHorizontal: CGFloat { 27 }
-        static var goToPlanButtonLabelframeHeight: CGFloat { 60 }
+        static var topSpacerHeight: CGFloat { 20.responsibleHeight }
+        static var ingredientsImagePaddingBottom: CGFloat { 45.responsibleHeight }
+        static var titleAndHintPaddingBottom: CGFloat { 30.responsibleHeight }
+        static var goToPlanButtonLabelPaddingHorizontal: CGFloat { 27.responsibleWidth }
+        static var goToPlanButtonLabelframeHeight: CGFloat { 60.responsibleHeight }
         static var goToPlanButtonLabelBackgroundCornerRadius: CGFloat { 50 }
         static var goToPlanButtonLabelBackgroundColor: Color { .accentColor1 }
-        static var modalHeight: CGFloat { 498 }
+        static var modalHeight: CGFloat { 498.responsibleHeight }
         static var modalPresentationCornerRadius: CGFloat { 25 }
+        static var buttonBottomSpace: CGFloat { 35.responsibleHeight }
     }
 }
 

--- a/Solidner/Views/Planning/Weekly/PlanListView.swift
+++ b/Solidner/Views/Planning/Weekly/PlanListView.swift
@@ -109,27 +109,16 @@ extension PlanListView {
                 isCurrentDateEditing.toggle()
             } label: {
                 Text(texts.yyyymmHeaderText(date: selectedMonthDate))
-                    .customFont(.header2, color: K.titleTextColor)
+                    .headerFont2()
+                    .foregroundStyle(Color.defaultText)
                     .padding(.trailing, 2)
-                Image(systemName: K.chevronDownSFSymbolName)
+                Image(systemName: "chevron.down")
                     .resizable()
                     .scaledToFit()
                     .frame(width: 20)
-                    .foregroundStyle(K.chevronDownColor)
+                    .foregroundStyle(Color.defaultText)
             }
-            Rectangle()
-                .foregroundStyle(Color.secondBgColor)
-                .frame(maxWidth: .infinity)
-                .frame(height: 31)
-                .onTapGesture(count: 5) {
-                    print("Tapped!")
-                    Task {
-                        try? await FirebaseManager.shared.deleteAllMealPlan(email: user.email)
-                        UserDefaults().set("", forKey: "nickName")
-                    }
-                }.gesture(TapGesture().onEnded { _ in
-                    print("tapped once")
-                })
+            Spacer()
         }
         .padding(K.titlePadding)
     }


### PR DESCRIPTION
## What I Did!
<!-- 작업 내용과 참고 스크린샷 첨부 -->

SE 기기에서의 아래 화면들을 기기에 맞게 디자인 수정하였습니다.
- 계획이 없을 때 초기 화면의 글자 잘림 및 이미지 크기 수정
- 마이페이지 스크롤뷰로 수정 및 상하 패딩값 조절
- 회원정보 수정 화면 스크롤뷰로 수정 및 상하 패딩값 조절
- 주간 플래닝 화면 헤더 측 년/월 선택 버튼이 두 줄로 표기되지 않도록 수정 (및 테스트용 코드 삭제)

아래 디자인들을 수정했습니다.
- 월간 플래닝 화면 최하단 이유식 전체 설정 버튼과의 패딩 수정

다음과 같은 기능들을 추가하고, 동작하지 않던 것들을 수정했습니다.
- 회원정보 수정에서 기존 닉네임과 아이 이름이 정상적으로 불러와지지 않던 것을 수정
- 닉네임과 아이 이름 수정 시 10자 이상이거나 빈 칸이면 버튼이 비활성화 되도록 변경
- 회원 정보 수정 시 정상적으로 DB에 연동되고, 비동기를 통해 userOB에 저장 및 에러 핸들링 구현



## Issue

<!-- 참고할 Issue와 연관된 Issue를 적어주세요. (ex. #1, close #2) -->

close #113 

