### PR TITLE
[Bug/#115] 첫째날에 주의 표시 안보이는 이슈 외

### DIFF
--- a/Solidner/Extension+/Date+.swift
+++ b/Solidner/Extension+/Date+.swift
@@ -174,11 +174,16 @@ extension Date {
     
     /// `formatted(_ format: DateFormat) -> String` 함수에 사용되는 format 형식을 case로 재정의한 enum입니다.
     enum DateFormat: String {
+        // 2023.12.08
         case yyyyMMdd_dot = "yyyy.MM.dd"
+        // 2023. 12. 08
         case yyyyMMdd_dotWithSpace = "yyyy. MM. dd"
+        // 2023년 12월 08일
         case yyyyMMdd_fullKorean = "yyyy년 MM월 dd일"
-        // 11/13
+        // 12/08
         case MMdd_slash = "MM/dd"
+        // 12. 8. (금)
+        case MMdE_dotWithSpace = "MM. d. (E)"
     }
 
     func isInBetween(from: Date, to: Date) -> Bool {

--- a/Solidner/Extension+/Date+.swift
+++ b/Solidner/Extension+/Date+.swift
@@ -182,7 +182,7 @@ extension Date {
     }
 
     func isInBetween(from: Date, to: Date) -> Bool {
-        self >= from && self <= to
+        self >= from.dayOfStart && self <= to.dayOfEnd
     }
 
     /// 이 Extension 내에서 정의한 DateFormat Enum 참고.

--- a/Solidner/Literal/TextLiterals.swift
+++ b/Solidner/Literal/TextLiterals.swift
@@ -36,7 +36,7 @@ enum TextLiterals {
     }
 
     enum PlanGroupDetail {
-        static func dateRangeTitle(from: Date, to: Date) -> String { "\(from.month).\(from.day).(\(from.weekDayKor)) ~ \n\(to.month).\(to.day).(\(to.weekDayKor)) 식단" }
+        static func dateRangeTitle(from: Date, to: Date) -> String { "\(from.formatted(.MMdE_dotWithSpace)) ~ \n\(to.formatted(.MMdE_dotWithSpace)) 식단" }
 
         static var editPlan: String { "편집" }
         static var editComplete: String { "완료" }
@@ -49,7 +49,7 @@ enum TextLiterals {
     }
 
     enum DailyPlanList {
-        static func titleText(_ date: Date) -> String { "\(date.month).\(date.day).(\(date.weekDayKor)) 식단" }
+        static func titleText(_ date: Date) -> String { "\(date.formatted(.MMdE_dotWithSpace)) 식단" }
         static func dateRangeString(start: Date, end: Date) -> String {
             "\(start.day)일(\(start.weekDayKor)) ~ \(end.day)일(\(end.weekDayKor))"
         }
@@ -131,13 +131,10 @@ enum TextLiterals {
 
     enum MealDetail {
         static func viewHeaderTitleText(from: Date, to: Date, isSingle: Bool) -> String {
-            func dateString(of date: Date) -> String {
-                return "\(date.month).\(date.day).(\(date.weekDayKor))"
-            }
             if isSingle {
-                return "\(dateString(of: from)) 재료"
+                return "\(from.formatted(.MMdE_dotWithSpace)) 재료"
             } else {
-                return "\(dateString(of: from)) ~ \(dateString(of: to)) 재료"
+                return "\(from.formatted(.MMdE_dotWithSpace)) ~ \(to.formatted(.MMdE_dotWithSpace)) 재료"
             }
             
         }

--- a/Solidner/ObservableObjects/MealPlansOB.swift
+++ b/Solidner/ObservableObjects/MealPlansOB.swift
@@ -105,7 +105,7 @@ final class MealPlansOB: ObservableObject {
     /// - Returns: date가 포함된 meal plan의 list
     func getMealPlans(in date: Date) -> [MealPlan] {
         mealPlans.filter {
-            date.isInBetween(from: $0.startDate.dayOfStart, to: $0.endDate.dayOfEnd)
+            date.isInBetween(from: $0.startDate, to: $0.endDate)
         }
     }
     
@@ -122,19 +122,19 @@ final class MealPlansOB: ObservableObject {
             filteredMealPlans = mealPlans
         case let .dateRange(start, end):
             filteredMealPlans = mealPlans.filter {
-                start.isInBetween(from: $0.startDate.dayOfStart, to: $0.endDate.dayOfEnd) || end.isInBetween(from: $0.startDate.dayOfStart, to: $0.endDate.dayOfEnd)
+                start.isInBetween(from: $0.startDate, to: $0.endDate) || end.isInBetween(from: $0.startDate, to: $0.endDate)
             }
         case let .month(date):
             #warning("test해봐야...")
             filteredMealPlans = mealPlans.filter {
                 let start = Date.date(year: date.year, month: date.month, day: 1) ?? Date()
-                let end = start.add(.month, value: 1).add(.day, value: -1).dayOfEnd
+                let end = start.add(.month, value: 1).add(.day, value: -1)
                 return $0.startDate.isInBetween(from: start, to: end) || $0.endDate.isInBetween(from: start, to: end)
 //                return ($0.startDate <= end && $0.startDate >= start) || ($0.endDate >= start && $0.endDate <= end)
             }
         case let .day(date):
             filteredMealPlans = mealPlans.filter {
-                date.isInBetween(from: $0.startDate.dayOfStart, to: $0.endDate.dayOfEnd)
+                date.isInBetween(from: $0.startDate, to: $0.endDate)
             }
         }
     }
@@ -175,7 +175,7 @@ final class MealPlansOB: ObservableObject {
     
     private func isWrongPlan(at date: Date, in plans: [MealPlan]) -> Bool {
         let relatedPlans = plans.filter { date.isInBetween(from: $0.startDate, to: $0.endDate) }
-        
+        print(#function, plans, relatedPlans)
         return WrongPlanChecker.isWrongPlan(relatedPlans)
     }
 }

--- a/Solidner/ObservableObjects/UserOB.swift
+++ b/Solidner/ObservableObjects/UserOB.swift
@@ -26,7 +26,7 @@ final class UserOB: ObservableObject {
     @AppStorage("babyBirthDate") var babyBirthDate = Date.date(year: 2023, month: 2, day: 22)!
     @AppStorage("solidStartDate") var solidStartDate = Date.date(year: 2023, month: 9, day: 22)!
     @AppStorage("planCycleGap") var planCycleGap = CycleGaps.three
-    @AppStorage("displayDateType") var displayDateType = DisplayDateType.birth
+    @AppStorage("displayDateType") var displayDateType = DisplayDateType.solid
 
     /// 생후 얼마가 지났는 지 불러옴.
     /// `UserOB.dateAfterBirth.day / UserOB.dateAfterBirth.month` 와 같은 형식으로 사용.

--- a/Solidner/Views/Components/TitleAndHintView.swift
+++ b/Solidner/Views/Components/TitleAndHintView.swift
@@ -71,7 +71,7 @@ extension TitleAndHintView {
         self.title = title
         self.hint = hint
         self._titleColor = State(initialValue: .defaultText.opacity(0.8))
-        self._hintColor = State(initialValue: .primary.opacity(0.6))
+        self._hintColor = State(initialValue: .primeText.opacity(0.6))
     }
 }
 

--- a/Solidner/Views/Planning/AddPlan/AddIngredientBigDivision.swift
+++ b/Solidner/Views/Planning/AddPlan/AddIngredientBigDivision.swift
@@ -142,7 +142,7 @@ extension IngredientsBigDivision {
             ForEach(Array(IngredientType.allCases.enumerated()), id: \.element) { index, type in
                 HStack(spacing: 0) {
                     Text(type.description)
-                        .font(.system(size: 19, weight: .semibold))
+                        .customFont(.header4, color: .defaultText.opacity(0.8))
                         .padding(.trailing, 2)
                     if divisionCase == .권장하지않는재료 {
                         Image(systemName: "xmark.shield.fill")
@@ -308,7 +308,7 @@ extension IngredientsBigDivision {
         var body: some View {
             HStack(spacing: 0) {
                 Text(ingredient.name)
-                    .headerFont4()
+                    .customFont(.header4, color: .defaultText.opacity(0.8))
                 Spacer().frame(width: ingredientNameRightSpace)
                 switch divisionCase {
                 case .이상반응재료:

--- a/Solidner/Views/Planning/Weekly/PlanGroupDetailView.swift
+++ b/Solidner/Views/Planning/Weekly/PlanGroupDetailView.swift
@@ -124,7 +124,7 @@ extension PlanGroupDetailView {
     private var headerTitle: some View {
         HStack(alignment: .top) {
             Text(texts.dateRangeTitle(from: startDate, to: endDate))
-                .headerFont2()
+                .customFont(.header2, color: .defaultText)
             Spacer()
         }
     }


### PR DESCRIPTION
## What I Did!
<!-- 작업 내용과 참고 스크린샷 첨부 -->

* [x] 주간 캘린더에서 주의 표시가 상단 일별 태그 첫 날 표시가 누락되는 이슈
* [x] 다크모드에서 글자 텍스트가 흰색으로 보이는 이슈
* [x] 날짜 생략 점 뒤에 띄어쓰기가 누락된 이슈
<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team15-GearCo/assets/107124308/13df59f5-5dab-42e7-9671-2fac6766a98d" width="30%"/> 
<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team15-GearCo/assets/107124308/b676d139-e016-4779-be28-115bdda1997f" width="30%"/> 

작업할 양이 많지 않아서 새로운 이슈를 파지 않고 한 곳에 몰아서 했습니다 sry

## Issue

close #115 

## Review Point
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
1. 주간 캘린더에서 주의 표시가 상단 일별 태그 첫 날 표시가 누락되는 이슈
기존은 isInBetween 메서드는 시간을 기준으로 판단했다. 
**앞으로도 시간보다는 날짜를 기준으로 판단할 것 같고 기존에 사용했던 용례도 모두 날짜 기준 판단이기에** (아니라면 수정 필요)
Date+의 isInBetween을 날짜 기준으로 수정했음.

https://github.com/DeveloperAcademy-POSTECH/MacC-Team15-GearCo/blob/66bdec560577d0c14cf54dd9965fb2a75616c223/Solidner/Extension%2B/Date%2B.swift#L189-L191

2. 다크모드에서 글자 텍스트가 흰색으로 보이는 이슈
TextView에 color를 따로 지정하지 않으면 default primary color가 지정되는데, 다크모드시 흰색으로 바뀜.
따라서 모든 TextView에 커스텀 컬러를 박아줘야 합니다.

3. 날짜 생략 점 뒤에 띄어쓰기가 누락된 이슈
새로운 format을 만들고 TextLiterals에 사용 
https://github.com/DeveloperAcademy-POSTECH/MacC-Team15-GearCo/blob/66bdec560577d0c14cf54dd9965fb2a75616c223/Solidner/Extension%2B/Date%2B.swift#L176-L187

## Reference & Image
<!-- 참고한 자료를 작성해주세요 -->
https://ownstory.tistory.com/21
<!-- <img src="ISSUE_TEMPLATE/이미지주소.png" width="200" height="400"/> >-->
<!-- <img src="이미지주소.png" width="40%"/> >-->

